### PR TITLE
Skip auth for the now public repo

### DIFF
--- a/scripts/integration_test/download.py
+++ b/scripts/integration_test/download.py
@@ -1,4 +1,3 @@
-import os
 import pathlib as p
 import platform
 import re
@@ -19,9 +18,7 @@ class Release(t.TypedDict):
 
 
 def download(*, out_dir: p.Path, tag: str) -> p.Path:
-    github_token = os.environ["GITHUB_TOKEN"]
     session = requests.Session()
-    session.headers.update({"Authorization": f"token {github_token}"})
     org = "temperlang"
     repo = "temper"
     # Get releases for tag.


### PR DESCRIPTION
- [Successful download here](https://github.com/temperlang/temper/actions/runs/21153457391/job/60833881609#step:13:16)
- To clarify, I got motivated on this because I had an old local token that was failing to authenticate and it made more sense at the moment to remove the need than to update my token