### PR TITLE
Stop requiring endline for semilit comment start

### DIFF
--- a/lexer/src/commonMain/kotlin/lang/temper/lexer/Lexer.kt
+++ b/lexer/src/commonMain/kotlin/lang/temper/lexer/Lexer.kt
@@ -1362,24 +1362,6 @@ class Lexer(
         return -1
     }
 
-    private inline fun skipChars(from: Int, p: (c: Char) -> Boolean): Int {
-        val text = sourceText
-        val limit = text.length
-        var pos = from
-        while (pos < limit) {
-            val c = text[pos]
-            if (!p(c)) {
-                return pos
-            }
-            pos += 1
-        }
-        return limit
-    }
-
-    private fun skipToLineEnd(from: Int): Int = skipChars(from) {
-        !LexicalDefinitions.isLineBreak(it)
-    }
-
     // We need to treat < and > specially when they are used as angle brackets as in
     //    : TypeName<TypeParameter>
     // but not in compound punctuation operators like

--- a/lexer/src/commonTest/kotlin/lang/temper/lexer/MarkdownLanguageConfigTest.kt
+++ b/lexer/src/commonTest/kotlin/lang/temper/lexer/MarkdownLanguageConfigTest.kt
@@ -162,18 +162,17 @@ class MarkdownLanguageConfigTest {
             |
             |    console.log("block 1");
             |    ${""}
-            |Ending one code block and beginning another.
+            |This text starts after trailing indentation. Now start more code.
             |
             |    console.log("block 2");
-            |
-            |Second ending.
+            |And this text obviously starts immediately after code.
         """.trimMargin(),
     ) { tokens ->
         assertEquals(
             listOf(
                 "Beginning a code block.",
-                "Ending one code block and beginning another.",
-                "Second ending.",
+                "This text starts after trailing indentation. Now start more code.",
+                "And this text obviously starts immediately after code.",
             ),
             tokens.mapNotNull {
                 unMassagedSemilitParagraphContent(it)


### PR DESCRIPTION
- Fix #299
- Stop requiring a blank line to end code blocks, since [it's not required in the CommonMark spec](https://spec.commonmark.org/0.31.2/#indented-code-blocks)