### PR TITLE
Keep type params off implied apply methods

### DIFF
--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/disambiguate/TypeDisambiguateMacro.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/disambiguate/TypeDisambiguateMacro.kt
@@ -178,6 +178,7 @@ internal fun typeDisambiguateMacro(
             val argsAfterWord = buildList {
                 for (i in args.indices) {
                     when (args.key(i)) {
+                        typeArgSymbol -> continue // Because this should stay on type only
                         wordSymbol -> continue // So we can use it as a type name
                         outTypeSymbol -> hasOutType = true
                     }

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
@@ -815,6 +815,44 @@ class DefineStageTest {
     )
 
     @Test
+    fun functionalInterfaceGeneric() = assertModuleAtStage(
+        stage = Stage.Define,
+        input = """
+            |export @fun interface MyFunction<T, U>(x: T, y: U): Boolean;
+        """.trimMargin(),
+        want = """
+            |{
+            |  define: {
+            |    body:
+            |      ```
+            |      @typeDecl(MyFunction<T__0, U__0>) @stay @functionalInterface let `test//`.MyFunction;
+            |      `test//`.MyFunction = type (MyFunction);
+            |      do {};
+            |      @typeFormal(\T) @typeDefined(T__0) @fromType(MyFunction<T__0, U__0>) let T__0;
+            |      T__0 = type (T__0);
+            |      @typeFormal(\U) @typeDefined(U__0) @fromType(MyFunction<T__0, U__0>) let U__0;
+            |      U__0 = type (U__0);
+            |      MyFunction<T__0, U__0> extends AnyValue;
+            |      @fn @stay @fromType(MyFunction<T__0, U__0>) let apply__0;
+            |      apply__0 = fn apply(x__0 /* aka x */: T__0, y__0 /* aka y */: U__0) /* return__0 */: Boolean {
+            |        fn__0: do {
+            |          pureVirtual()
+            |        }
+            |      };
+            |      interface(\word, \MyFunction, void, void, void, void, \concrete, false, @typeDefined(MyFunction<T__0, U__0>) fn {
+            |          do {};
+            |          do {};
+            |          do {};
+            |          do {}
+            |      });
+            |
+            |      ```
+            |  }
+            |}
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
+
+    @Test
     fun coalesce() = assertModuleAtStage(
         stage = Stage.Define,
         input = """

--- a/functional-test-suite/src/commonMain/resources/functions/locals/locals.temper.md
+++ b/functional-test-suite/src/commonMain/resources/functions/locals/locals.temper.md
@@ -175,11 +175,11 @@ mutualRecursion = [2, 4, 6]
 Capture scope can also get tricky across languages. Here we gather up some
 closures with capture from a loop var.
 
-    let hub = new Hub();
+    let hub = new Hub<Int>();
     let items = gatherHandlers(hub);
-    hub.actionPerformed();
+    hub.actionPerformed(1);
 
-    let gatherHandlers(hub: Hub): ListBuilder<Int> {
+    let gatherHandlers(hub: Hub<Int>): ListBuilder<Int> {
       let items = new ListBuilder<Int>();
       for (var i = 0; i < 3; i++) {
 
@@ -187,8 +187,8 @@ Ideally, we don't need `let i = i;` but our `for` desugaring fails to capture
 the changing value without this.
 
         let i = i;
-        hub.onAction {
-          items.add(i);
+        hub.onAction { item =>
+          items.add(item + i);
           // console.log("items: ${items.join(" ") { i => i.toString() }}");
         }
       }
@@ -197,18 +197,18 @@ the changing value without this.
 
 This could represent any kind of event system.
 
-    @fun interface Handler(): Void;
+    @fun interface Handler<T>(item: T): Void;
 
-    class Hub {
-      private handlers: ListBuilder<Handler> = new ListBuilder();
+    class Hub<T> {
+      private handlers: ListBuilder<Handler<T>> = new ListBuilder();
 
-      public onAction(handler: Handler): Void {
+      public onAction(handler: Handler<T>): Void {
         handlers.add(handler);
       }
 
-      public actionPerformed(): Void {
+      public actionPerformed(item: T): Void {
         for (var i = 0; i < handlers.length; ++i) {
-          handlers[i]();
+          handlers[i](item);
         }
       }
     }
@@ -219,7 +219,7 @@ Python without extra attention has all `2` values below. And without
 Note that this is ignored until we fix Python.
 
 ```ignore log
-items: 0
-items: 0 1
-items: 0 1 2
+items: 1
+items: 1 2
+items: 1 2 3
 ```


### PR DESCRIPTION
- Fix this:

```ts
    @fun interface ContextPropagator<CONTEXT>(
      before: CONTEXT,
      literalPart: String?,
    ): AdjustedStringAndContextAfter<CONTEXT>;
```

causing this:

```ts
7: e ContextPropagator<CONTEXT>(
                       ⇧
[-work/src/core/context-autoescaping.temper.md:7+37]@A: Illegal type parameter CONTEXT. Overridable methods don't allow generics
```

by keeping type params only on the type, not on the method.
