### PR TITLE
be: fix methods on type params

### DIFF
--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/TranslateDotHelper.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/TranslateDotHelper.kt
@@ -58,7 +58,7 @@ internal object TranslateDotHelper {
                             is DefinedType ->
                                 add(t.withNullity(Nullity.NonNull) as DefinedNonNullType)
                             is TypeParamRef -> {
-                                for (ub in definition.upperBounds) {
+                                for (ub in t.definition.upperBounds) {
                                     explodeUpperBounds(hackMapOldStyleToNew(ub))
                                 }
                             }
@@ -91,8 +91,9 @@ internal object TranslateDotHelper {
         }
 
     /** TODO Any way to unify this with [DotHelper] lookup logic? */
-    private fun findMembers(subjectTypes: List<DefinedNonNullType>, fn: DotHelper): Set<MethodShape> = buildSet {
+    private fun findMembers(subjectTypes: List<DefinedNonNullType>, fn: DotHelper): Set<MethodShape> {
         val commonMembers = mutableSetOf<MethodShape>()
+
         subjectTypes.forEachIndexed { index, memberType ->
             val members = findMembers(memberType.definition, fn)
             if (index == 0) {
@@ -101,7 +102,7 @@ internal object TranslateDotHelper {
                 commonMembers.retainAll(members)
             }
         }
-        commonMembers.toSet()
+        return commonMembers
     }
 
     private fun findConnectedMember(members: Set<MethodShape>): Pair<MethodShape, String>? {
@@ -173,6 +174,7 @@ internal object TranslateDotHelper {
         val subjectIndexInCallTree = 1 + dotHelper.memberAccessor.firstArgumentIndex
         val subjectTypeDefinition = callTree.children[subjectIndexInCallTree].typeOrInvalid.definition
         val members: Set<MethodShape> = findMembers(subjectTypeDefinition, dotHelper)
+
         val firstMember: MethodShape? = members.firstOrNull()
         val adjustments = firstMember?.let {
             translator.metadataFetcher().read(it.name, SignatureAdjustments.KeyFactory)
@@ -384,7 +386,7 @@ internal object TranslateDotHelper {
                 )
             }
             is BindMemberAccessor -> if (outerCallTree != null) {
-                val method = members.firstOrNull()
+                val method = firstMember
                     ?: return TranslatedDotHelper(
                         Either.Left(
                             garbageExpr(pos, "No method matching .${dotHelper.symbol.text} in $subjectTypeDefinition"),

--- a/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
@@ -4115,6 +4115,54 @@ class TmpLBackendTest {
         """.trimMargin(),
     )
 
+    @Test
+    fun methodOnGeneric() = assertGeneratedCode(
+        supportNetwork = TestSupportNetwork(functionTypeStrategy = FunctionTypeStrategy.ToFunctionalInterface),
+        inputs = inputFileMapFromJson(
+            """
+                |{
+                |  foo: {
+                |    foo.temper:
+                |      ```
+                |      export interface Foo {
+                |        foo(): Void;
+                |      }
+                |      export let f<T extends Foo>(x: T): Void {
+                |        x.foo()
+                |      }
+                |      ```
+                |  },
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |  tmpl: {
+            |    foo.tmpl: {
+            |      content:
+            |        ```
+            |        //// work//foo/ => foo.tmpl
+            |        require temper-core;
+            |        let InterfaceTypeSupport#0 = InterfaceTypeSupport;
+            |        let pureVirtual#0 = builtins.pureVirtual;
+            |        @QName("test-library/foo.type Foo") interface Foo / Foo {
+            |          @QName("test-library/foo.type Foo.foo()") let foo__0(this = this__0, @QName("test-library/foo.type Foo.foo().(this)") @impliedThis(Foo) this__0: Foo): Void {
+            |            pureVirtual#0();
+            |          }
+            |        }
+            |        @QName("test-library/foo.f()") let f<T__0 extends Foo>(@QName("test-library/foo.f().(x)") x__0: T__0): Void {
+            |          x__0.foo();
+            |          return;
+            |        }
+            |
+            |        ```
+            |    },
+            |    foo.tmpl.map: "__DO_NOT_CARE__",
+            |  }
+            |}
+        """.trimMargin(),
+    )
+
     private fun assertGeneratedCode(
         inputJsonPathToContent: String,
         want: String,


### PR DESCRIPTION
Multiple minor bugs prevented calling a method when the subject type was a simple type parameter directly.