### PR TITLE
be-js: Stop adding return type to garbage expressions

### DIFF
--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
@@ -1771,12 +1771,12 @@ internal class JsTranslator(
 
     private fun translateGarbage(g: TmpL.Garbage): Js.Expression = Js.CallExpression(
         pos = g.pos,
+        // TypeScript can infer return type never on this.
         callee = Js.ArrowFunctionExpression(
             pos = g.pos,
             params = Js.Formals(
                 pos = g.pos.leftEdge,
                 params = listOf(),
-                returnType = Js.Identifier(g.pos.leftEdge, JsIdentifierName("never"), null),
             ),
             body = Js.BlockStatement(
                 g.pos,

--- a/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
+++ b/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
@@ -1307,13 +1307,14 @@ class JsBackendTest {
                 |}
             """.trimMargin(),
         ),
+        // This had an explicit TypeScript-style `never` return type on it, but we should use just JS.
         want = """
             |{
             |  js: {
             |    "my-test-library": {
             |      "foo.js": {
             |        content: ```
-            |          (((): never => {
+            |          ((() => {
             |                throw "howAboutThis not available from implicits";
             |            })());
             |


### PR DESCRIPTION
- Avoid TypeScript `never` return type in js garbage expressions
- Ran across this when I had a bug temporarily in some code I was working on
- Also, TypeScript can infer the type without it:

<img width="1668" height="620" alt="image" src="https://github.com/user-attachments/assets/f1a16bde-951b-409a-a1ba-397d470e910e" />
