### PR TITLE
be-rust: Avoid use trait from current module

### DIFF
--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -1524,7 +1524,10 @@ class RustTranslator(
                     is TmpL.Expression -> {
                         callable.method?.enclosingType?.let traitImport@{ owner ->
                             // TODO Do we need to filter out implicits? So far, no examples of hitting that case.
-                            if (owner.abstractness == Abstractness.Abstract && owner.pos.loc != module.pos.loc) {
+                            if (
+                                owner.abstractness == Abstractness.Abstract &&
+                                owner.sourceLocation != module.codeLocation.codeLocation
+                            ) {
                                 // For actual interface methods, we shouldn't have name collisions.
                                 // TODO Can/should we provide traits for extension methods?
                                 // TODO If so, just translate those as qualified calls anyway?

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -128,7 +128,6 @@ class RustBackendTest {
             |              use temper_core::AnyValueTrait;
             |              use temper_core::AsAnyValue;
             |              use temper_core::Pair;
-            |              use TalkerTrait;
             |              pub (crate) fn init() -> temper_core::Result<()> {
             |                  static INIT_ONCE: std::sync::OnceLock<temper_core::Result<()>> = std::sync::OnceLock::new();
             |                  INIT_ONCE.get_or_init(| |{


### PR DESCRIPTION
- Fix bogus trait `use` from same module
- This bug is a compiler error in rust, so it's good to fix