### PR TITLE
be-java: protected visibility

### DIFF
--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
@@ -2393,9 +2393,26 @@ class JavaTranslator(
 
 private fun access(name: TmpL.Id) = access(name.name is ExportedName)
 
-private fun access(member: TmpL.Member) =
+private fun access(member: TmpL.Member): J.ModAccess {
+    val visibility = member.visibility.visibility
+
+    if (visibility == TmpL.Visibility.Protected) {
+        // Temper allows protected in interfaces, but Java does not.
+        // TODO: a better way to discourage non-internal use.
+        val memberShape = member.memberShape
+        val enclosingType = memberShape.enclosingType
+        if (enclosingType.abstractness == Abstractness.Concrete) {
+            return if (memberShape.overriddenMembers?.isEmpty() == true) {
+                J.ModAccess.Protected
+            } else {
+                J.ModAccess.Public
+            }
+        }
+    }
+
     // TODO: private means not inherited, unlike package private below
-    access(member.memberShape.visibility >= Visibility.Public)
+    return access(pub = visibility >= TmpL.Visibility.Public)
+}
 
 private fun access(pub: Boolean?) = when (pub) {
     true -> J.ModAccess.Public

--- a/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
+++ b/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
@@ -2171,4 +2171,63 @@ class JavaBackendTest {
         ),
         langs = listOf(JavaLang.Java17), // listOf
     )
+
+    @Test
+    fun protectedInInterfaces() = assertGeneratedJavaRaw(
+        input = """
+            |export interface I {
+            |  f(): Void { g() }
+            |  protected g(): Void;
+            |}
+            |
+            |export class C extends I {
+            |  protected g(): Void {}
+            |}
+        """.trimMargin(),
+        want = """
+            |src: {
+            |  main: {
+            |    java: {
+            |      my_test_library: {
+            |        test: {
+            |          I.java: {
+            |            content: ```
+            |              package my_test_library.test;
+            |              public interface I {
+            |                  default void f() {
+            |                      this.g();
+            |                  }
+            |                  void g();
+            |              }
+            |
+            |              ```,
+            |          },
+            |          C.java: {
+            |            content: ```
+            |              package my_test_library.test;
+            |              public final class C implements I {
+            |                  public void g() {
+            |                  }
+            |                  public C() {
+            |                  }
+            |              }
+            |
+            |              ```,
+            |          },
+            |          TestMain.java: "__DO_NOT_CARE__",
+            |          TestGlobal.java: "__DO_NOT_CARE__",
+            |          C.java.map: "__DO_NOT_CARE__",
+            |          I.java.map: "__DO_NOT_CARE__",
+            |          TestMain.java.map: "__DO_NOT_CARE__",
+            |          TestGlobal.java.map: "__DO_NOT_CARE__",
+            |        },
+            |        MyTestLibraryMain.java: "__DO_NOT_CARE__",
+            |        MyTestLibraryGlobal.java: "__DO_NOT_CARE__",
+            |      },
+            |    },
+            |  },
+            |},
+            |pom.xml: "__DO_NOT_CARE__",
+        """.trimMargin(),
+    )
 }


### PR DESCRIPTION
Java has `protected` visibility meaning an implementation detail that is visible to subclasses but which has privileged access to `private` members in its declaring class.

Java does not allow `protected` members on interfaces or `private`, non-`static` members.

This commit fixes a problem with translation of Temper `protected`.

    interface I {
      public f() { g() }
      protected g();
    }

    class C extends I {
      protected g() { ... }
    }

Here, the interface declares `g()` and uses it.
The Java translation of `class C` needs to meet another Java requirement:

[JLS &sect;8.4.8.3](https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.4.8.3)

> The access modifier of an overriding or hiding method must provide
> at least as much access as the overridden or hidden method, as
> follows:
>
> - If the overridden or hidden method is public, then the overriding
>   or hiding method must be public; otherwise, a compile-time error
>   occurs.

Now, when producing method declarations, we raise the visibility of the declared method if the Temper method being translated is a Temper class method, has protected visibility, and overrides an interface method.

JavaTranslator already treats all instance methods defined on interfaces as public.  This is not ideal but this fix is consistent with that.  Recreating `protected` status in Java would be nice, and we have bandied around approaches to making use of hiddens awkward in target PLs that do not have robust & fine-grained information hiding.