### PR TITLE
std/regex: some minor fixes

### DIFF
--- a/be-js/src/commonMain/resources/lang/temper/be/js/temper-core/regex.js
+++ b/be-js/src/commonMain/resources/lang/temper/be/js/temper-core/regex.js
@@ -113,6 +113,16 @@ export const regexCompiledSplit = (_, compiled, text) => {
  * @returns {RegExp}
  */
 export const regexCompileFormatted = (_, formatted) => {
+  if (formatted.includes("\\&")) {
+    // std/regex escapes '&' because that's needed on Python, but
+    // EcmaScript's builtin complains.
+    formatted = formatted.replace(
+      /\\+&/g,
+      // If the length is even, then it is escaped because the number of
+      // backslashes preceding is odd.
+      (s) => (s.length & 1 ? s : s.substring(1))
+    );
+  }
   return new RegExp(formatted, "dgu"); // d:hasIndices, g:global, u:unicode
 };
 

--- a/frontend/src/commonMain/resources/std/regex/regex.temper.md
+++ b/frontend/src/commonMain/resources/std/regex/regex.temper.md
@@ -685,7 +685,7 @@ let needsNumericEscape = 1;
 let needsSimpleEscape = 2;
 let buildEscapeNeeds(): List<Int> {
   let escapeNeeds = new ListBuilder<Int>();
-  for (var code = 0; code < 0x7F; code += 1) {
+  for (var code = 0; code <= 0x7F; code += 1) {
     escapeNeeds.add(
       if (
         // Dash needs escaping in code sets, but we'll handle that specially.
@@ -699,6 +699,7 @@ let buildEscapeNeeds(): List<Int> {
         needsNoEscape
       } else if (
         // Ampersand and tilde need escaped only in python for now, but meh.
+        // Escaping ampersand breaks JS though.  Fix that in temper-core/regex.js
         code == Codes.ampersand ||
         code == Codes.backslash ||
         code == Codes.caret ||

--- a/interp/src/commonMain/kotlin/lang/temper/interp/LazyActualsList.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/LazyActualsList.kt
@@ -134,7 +134,7 @@ class LazyActualsList(
     }
 
     override fun keyTree(index: Int): Tree? {
-        if (keys[index] == null) { return null }
+        if (index !in keys.indices || keys[index] == null) { return null }
         return rawTreeList[treeIndex[index] - 1]
     }
 


### PR DESCRIPTION
regex compilation escapes `&` but JavaScript complains when it is escaped.

```js
$ node
Welcome to Node.js v25.2.1.
Type ".help" for more information.
> new RegExp("\\&")
/\&/
> new RegExp("\\&", "dgu")
Uncaught SyntaxError: Invalid regular expression: /\&/dgu: Invalid escape
> new RegExp("[&]", "dgu")
/[&]/dgu
```

There is a note in std/regex that Python requires escaping `&`.

This commit reworks the core.js function that creates the RegExp to unescape `&` specifically.

This also fixes a problem in regex.temper.md where code checks `<= 127` before looking into the list of safe ASCII codepoints, but the code that assembles the list does `< 127` leading to panics when compiling a regular expression that explicitly mentions U+7f.