### PR TITLE
some improvements for better debugging via REPL

### DIFF
--- a/cli/src/main/kotlin/lang/temper/cli/Cli.kt
+++ b/cli/src/main/kotlin/lang/temper/cli/Cli.kt
@@ -435,6 +435,17 @@ abstract class Main {
                             append(HELP_INDENT) // followed by type description
                         },
                     ).default(ReplPrompt.default)
+                    val execBefore = option(
+                        ArgType.String,
+                        shortName = "e",
+                        fullName = "exec-before",
+                        description = buildString {
+                            append("Temper code to execute before the first user prompt.\n")
+                            append(HELP_INDENT)
+                            append("This can help set up frequently used imports.\n")
+                            append(HELP_INDENT) // followed by type description
+                        },
+                    ).multiple()
 
                     override fun execute() {
                         // If we have a backend
@@ -463,6 +474,11 @@ abstract class Main {
                                     prompt = prompt.value,
                                 ),
                             )
+
+                            // Processing these here avoids any interaction with history.
+                            for (temperCommand in execBefore.value) {
+                                repl.processLine(temperCommand)
+                            }
 
                             val isTtyLike = repl.console.textOutput.isTtyLike
                             val lineReader = LineReaderBuilder.builder()

--- a/cli/src/main/kotlin/lang/temper/cli/repl/Repl.kt
+++ b/cli/src/main/kotlin/lang/temper/cli/repl/Repl.kt
@@ -21,6 +21,7 @@ import lang.temper.frontend.Module
 import lang.temper.frontend.ModuleSource
 import lang.temper.frontend.StagingFlags
 import lang.temper.frontend.implicits.ImplicitsModule
+import lang.temper.frontend.staging.makeContinueCondition
 import lang.temper.fs.Directories
 import lang.temper.interp.MetadataDecorator
 import lang.temper.interp.convertToErrorNode
@@ -337,11 +338,7 @@ internal class Repl(
         commandCount += 1 // Next loc will be different
 
         // Execute the command
-        var stepsThousands = MAX_STEPS_THOUSANDS
-        val continueCondition = {
-            stepsThousands -= 1
-            stepsThousands > 0
-        }
+        val continueCondition = makeContinueCondition()
         // Set up the module
         val module = Module(
             logSink,
@@ -389,13 +386,11 @@ internal class Repl(
             try {
                 module.advance()
             } catch (panic: Panic) {
-                ignore(panic)
                 console.error("Interpretation ended due to runtime panic")
                 if (console.logs(Log.Fine)) {
                     console.error(panic)
                 }
             } catch (abort: Abort) {
-                ignore(abort)
                 console.error("Interpretation aborted")
                 if (console.logs(Log.Fine)) {
                     console.error(abort)
@@ -579,8 +574,6 @@ internal class Repl(
 internal const val INITIAL_COMMAND_COUNT = 0
 internal const val REPL_LOC_PREFIX = "interactive#"
 internal val REPL_LOC_SYMBOL = Symbol(REPL_LOC_PREFIX.replace("#", ""))
-
-private const val MAX_STEPS_THOUSANDS = 100
 
 private fun exportTopLevels(module: Module, root: BlockTree): BlockTree {
     fun maybeExport(edge: TEdge) {

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/GenerateCodeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/GenerateCodeStage.kt
@@ -190,6 +190,7 @@ class GenerateCodeStage(
 
         ReachabilityTracer().markReachability(root)
         ExportChecker(module).checkExports()
+        TypeDeclChecker(module, logSink).checkDeclaredTypeShapes()
 
         Debug.Frontend.GenerateCodeStage.After.snapshot(configKey, AstSnapshotKey, root)
     }

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/TypeDeclChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/TypeDeclChecker.kt
@@ -1,0 +1,140 @@
+package lang.temper.frontend.generate
+
+import lang.temper.common.Log
+import lang.temper.frontend.Module
+import lang.temper.log.LogSink
+import lang.temper.log.MessageTemplate
+import lang.temper.log.unknownPos
+import lang.temper.name.Symbol
+import lang.temper.type.Abstractness
+import lang.temper.type.MethodKind
+import lang.temper.type.MethodShape
+import lang.temper.type.TypeShape
+import lang.temper.type.Visibility
+import lang.temper.type.WellKnownTypes
+import lang.temper.type2.DefinedNonNullType
+import lang.temper.type2.MkType2
+import lang.temper.type2.Signature2
+import lang.temper.type2.SuperTypeTree2
+import lang.temper.type2.mapType
+import lang.temper.value.connectedSymbol
+import lang.temper.value.parameterNameSymbols
+
+internal class TypeDeclChecker(val module: Module, val logSink: LogSink) {
+    private val abstractMethodCache = mutableMapOf<TypeShape, List<MethodDescriptor>>()
+
+    fun checkDeclaredTypeShapes() {
+        for (typeShape in module.declaredTypeShapes) {
+            when (typeShape.abstractness) {
+                Abstractness.Abstract -> {}
+                Abstractness.Concrete -> checkAllMethodsOverridden(typeShape)
+            }
+        }
+    }
+
+    private fun checkAllMethodsOverridden(typeShape: TypeShape) {
+        val superTypeShapes = mutableSetOf<TypeShape>()
+        fun walk(ts: TypeShape) {
+            if (ts !in superTypeShapes) {
+                superTypeShapes.add(ts)
+                for (x in ts.superTypes) {
+                    walk(x.definition as TypeShape)
+                }
+            }
+        }
+        walk(typeShape)
+
+        val isProcessingImplicits = module.isEffectivelyImplicits
+        val isStd = module.isEffectivelyStd
+        val allAbstractMethodDescriptors = mutableListOf<MethodDescriptor>()
+        for (strictSuperTypeShape in superTypeShapes) {
+            val abstractMethods = abstractMethodCache.getOrPut(strictSuperTypeShape) {
+                strictSuperTypeShape.methods.mapNotNull { m ->
+                    if (isProcessingImplicits && connectedSymbol in m.metadata) {
+                        null // Some Implicits methods have no body because they must connect.
+                    } else if (isStd && m.visibility == Visibility.Private && connectedSymbol in m.metadata) {
+                        null // std has some required connections too which are sneakily hidden away
+                    } else if (m.methodKind != MethodKind.Constructor && m.isPureVirtual) {
+                        MethodDescriptor(m.symbol, m.methodKind, m)
+                    } else {
+                        null
+                    }
+                }
+            }
+            allAbstractMethodDescriptors.addAll(abstractMethods)
+        }
+
+        val needed = allAbstractMethodDescriptors.filter { abstractMember ->
+            val word = abstractMember.word
+            val kind = abstractMember.methodKind
+            superTypeShapes.none { superTypeShape ->
+                superTypeShape.methods.any {
+                    it.methodKind == kind && it.symbol == word && !it.isPureVirtual
+                }
+            }
+        }
+        for (descriptor in needed) {
+            val word = descriptor.word
+            val example = descriptor.example
+            val kind = descriptor.methodKind
+            val description = when (kind) {
+                MethodKind.Normal -> word.text
+                MethodKind.Getter -> "get ${word.text}"
+                MethodKind.Setter -> "set ${word.text}"
+                MethodKind.Constructor -> "constructor"
+            }
+            val sigInContext = run {
+                val type = MkType2(typeShape).actuals(
+                    typeShape.formals.map { MkType2(it).get() },
+                ).get() as DefinedNonNullType
+                val superTypeInContext = SuperTypeTree2.of(type)[example.enclosingType].firstOrNull()
+                var sig = example.descriptor
+                    ?: Signature2(WellKnownTypes.voidType2, false, listOf())
+                if (sig.hasThisFormal) { sig = sig.copy(requiredInputTypes = sig.requiredInputTypes.drop(1)) }
+                if (superTypeInContext != null) {
+                    val bindings = (example.enclosingType.formals zip superTypeInContext.bindings).associate { it }
+                    sig = sig.mapType(bindings)
+                }
+                sig
+            }
+
+            val skeletonCode = buildString {
+                append("public $description(")
+                val parameterNameSymbols = example.parameterNameSymbols?.let {
+                    it.requiredSymbols + it.optionalSymbols
+                }
+                for ((i, vf) in sigInContext.allValueFormals.withIndex()) {
+                    val name = parameterNameSymbols?.getOrNull(i)?.text ?: "_"
+                    if (i != 0) { append(", ") }
+                    append("$name: ${vf.type}")
+                }
+                append("): ${sigInContext.returnType2}")
+            }
+            logSink.log(
+                Log.Error,
+                MessageTemplate.MissingMethodDefinition,
+                typeShape.stayLeaf?.pos ?: unknownPos,
+                listOf(
+                    typeShape.name,
+                    description,
+                    example.enclosingType.name,
+                    skeletonCode,
+                ),
+            )
+        }
+    }
+}
+
+private class MethodDescriptor(
+    val word: Symbol,
+    val methodKind: MethodKind,
+    val example: MethodShape,
+) {
+    override fun equals(other: Any?): Boolean =
+        other is MethodDescriptor && word == other.word && methodKind == other.methodKind
+    // example is non-normative
+
+    override fun hashCode(): Int = word.hashCode() + 31 * methodKind.hashCode()
+
+    override fun toString(): String = "MethodDescriptor($word, $methodKind)"
+}

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/ModuleAdvancer.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/ModuleAdvancer.kt
@@ -460,7 +460,7 @@ class ModuleAdvancer(
     }
 }
 
-private const val STEP_QUOTA = 1_000 // Thousands
+private const val STEP_QUOTA = 10_000 // Thousands
 
 private class MutLibraryConfigurations : Iterable<LibraryConfiguration> {
     private val configurationsPossiblyUnsorted = mutableListOf<LibraryConfiguration>()

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/Typer.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/Typer.kt
@@ -866,7 +866,7 @@ internal class Typer(
                             val formal = sig.valueFormalForActual(argIndex)?.type
                             if (formal != null) {
                                 return@findContext formal.mapType(
-                                    decision.bindings?.mapValues { hackMapOldStyleToNew(it as StaticType) }
+                                    decision.bindings?.mapValues { (_, a) -> hackMapOldStyleToNew(a as StaticType) }
                                         ?: mapOf(),
                                 )
                             }

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
@@ -3712,6 +3712,23 @@ class GenerateCodeStageTest {
             |}
         """.trimMargin(),
     )
+
+    @Test
+    fun pureVirtualMethodInConcreteClass() = assertModuleAtStage(
+        stage = Stage.Run,
+        input = """
+            |export interface I<T> { f(x: T): Void; }
+            |export class C extends I<String> {
+            |  // but does not override f()
+            |}
+        """.trimMargin(),
+        want = """
+            |{
+            |  run: "void: Void",
+            |  errors: ["Type C must implement f from I.  Maybe add `public f(x: String): Void`!"]
+            |}
+        """.trimMargin(),
+    )
 }
 
 // Provide an extra binding to a function whose call does not inline so does not trigger any

--- a/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
+++ b/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
@@ -112,6 +112,10 @@ enum class MessageTemplate(
         "Members of class %s require explicit visibility: %s",
         CompilationPhase.Interpreter,
     ),
+    MissingMethodDefinition(
+        "Type %s must implement %s from %s.  Maybe add `%s`",
+        CompilationPhase.Interpreter,
+    ),
     TypeCheckRejected("Type %s rejected value %s", CompilationPhase.Interpreter),
     BuiltinEnvironmentIsNotMutable(
         "Cannot declare locals (e.g. %s) in the builtin environment",


### PR DESCRIPTION
When testing in the REPL often there are some actions to take before you get to the exploratory work like `import`ing required libraries. This commit adds the `-e` flag so that the below runs an import before the REPL starts accepting user input.  Because it's separate, the `-e` commands do not show up in the user's history.

    temper repl -e 'let { ... } = import("std/temporal");'

I've been dogfooding and running into problems because Temper lacks a static check that `class` types implement all the `interface` methods they're supposed to.  That now happens in TypeDeclCheck.

For example:

    export interface I<T> { f(x: T): Void; }
    export class C extends I<String> {
      // but does not override f()
    }

> Type C must implement f from I.  Maybe add `public f(x: String): Void`

This also opportunistically fixes a type error (hit when typing `[^]` in the REPL without `rgx"..."` around it) in Typer.  It also sets REPL's very low continue condition quota to the same as ModuleAdvancer.