### PR TITLE
Fix bug: complex types were mis-inserted

### DIFF
--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeSyntaxMacro.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeSyntaxMacro.kt
@@ -299,9 +299,15 @@ internal fun typeSyntaxMacro(macroEnv: MacroEnvironment): PartialResult {
                                     val temporary = nameMaker.unusedTemporaryName(
                                         "typeof_${propertyNameSymbol.text}",
                                     )
-                                    val typeEdgeIndex = typeEdge.edgeIndex
+                                    val typeInsertionPoint = run {
+                                        var e = typeEdge!! // The target is not null
+                                        while (e.source != classBody) {
+                                            e = e.source!!.incoming!!
+                                        }
+                                        e.edgeIndex
+                                    }
                                     val simpleTypeExpr = RightNameLeaf(doc, typeTree.pos, temporary)
-                                    classBody.insert(typeEdgeIndex - 1) {
+                                    classBody.insert(typeInsertionPoint) {
                                         Decl(typeTree.pos) {
                                             Replant(simpleTypeExpr.copyLeft())
                                             V(vInitSymbol)

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
@@ -1750,9 +1750,10 @@ class DefineStageTest {
             |      @typeDecl(What__0<Thing__0>) @stay let What__0 = type (What__0);
             |      class(\word, \What, \concrete, true, @typeDefined(What__0<Thing__0>) fn {
             |          @typeFormal(\Thing) @memberTypeFormal(\Thing) @typeDefined(Thing__0) let Thing__0 = type (Thing__0);
-            |          let typeof_things#0 = List<Thing__0>, typeof_ints#0 = List<Int>;
             |          What__0<Thing__0> extends AnyValue;
+            |          let typeof_ints#0 = List<Int>;
             |          @constructorProperty @property(\ints) @maybeVar @visibility(\public) let ints__0: typeof_ints#0;
+            |          let typeof_things#0 = List<Thing__0>;
             |          @constructorProperty @property(\things) @maybeVar @visibility(\public) let things__0: typeof_things#0;
             |          @method(\work) @visibility(\public) @fn let work__0 = fn work(@impliedThis(What__0<Thing__0>) this__0: What__0<Thing__0>, that__0 /* aka that */: Thing__0) /* return__0 */: (Void) {
             |            fn__0: do {
@@ -1781,12 +1782,12 @@ class DefineStageTest {
             |      ```
             |      @typeFormal(\Thing) @memberTypeFormal(\Thing) @typeDefined(Thing__0) @fromType(What__0<Thing__0>) let Thing__0;
             |      Thing__0 = type (Thing__0);
-            |      let typeof_things#0;
-            |      typeof_things#0 = type (List<Thing__0>);
+            |      What__0<Thing__0> extends AnyValue;
             |      let typeof_ints#0;
             |      typeof_ints#0 = type (List<Int32>);
-            |      What__0<Thing__0> extends AnyValue;
             |      @constructorProperty @property(\ints) @visibility(\public) @stay @fromType(What__0<Thing__0>) let ints__0: List<Int32>;
+            |      let typeof_things#0;
+            |      typeof_things#0 = type (List<Thing__0>);
             |      @constructorProperty @property(\things) @visibility(\public) @stay @fromType(What__0<Thing__0>) let things__0: List<Thing__0>;
             |      @method(\work) @visibility(\public) @fn @stay @fromType(What__0<Thing__0>) let work__0;
             |      work__0 = fn work(@impliedThis(What__0<Thing__0>) this__0: What__0<Thing__0>, that__0 /* aka that */: Thing__0) /* return__0 */: Void {


### PR DESCRIPTION
When processing constructor properties during the syntax macro stage, we have to copy the type from the constructor argument to the property declaration.  If the type has not fully resolved, we might insert a temporary to avoid multiply evaluating a complex expression.

The intent of the code was to insert it before the constructor property in the class body, but it was using the edgeIndex in the property DeclTree, not in the class body BlockTree.

This caused problems when the type expression depends on a type parameter and that type parameters DeclTree is after index 2 (the common location for type metadata on a DeclTree), for example, because there are two or more type parameters on the class.

This fixes it by scanning up to the class body.