### PR TITLE
Apply backend bindings for watch

### DIFF
--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -115,14 +115,7 @@ fun prepareBuild(
         return null
     }
 
-    val pluggedInConfig = moduleConfig.copy(
-        moduleCustomizeHook = { module, isNew ->
-            moduleConfig.moduleCustomizeHook.customize(module, isNew)
-            for (backendId in supportedBackends) {
-                module.addEnvironmentBindings(lookupFactory(backendId)!!.environmentBindings)
-            }
-        },
-    )
+    val pluggedInConfig = plugInBackendConfigs(moduleConfig)
     return Build(
         harness = h,
         requiredExt = requiredExt,
@@ -130,6 +123,19 @@ fun prepareBuild(
         moduleConfig = pluggedInConfig,
     )
 }
+
+/** Applies environment bindings for [backends]. */
+fun plugInBackendConfigs(
+    moduleConfig: ModuleConfig,
+    backends: List<BackendId> = supportedBackends,
+): ModuleConfig = ModuleConfig(
+    moduleCustomizeHook = { module, isNew ->
+        moduleConfig.moduleCustomizeHook.customize(module, isNew)
+        for (backendId in backends) {
+            module.addEnvironmentBindings(lookupFactory(backendId)!!.environmentBindings)
+        }
+    },
+)
 
 /** [Prepare][prepareBuild]s and executes a build, closing the harness afterward. */
 fun doBuild(

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Watcher.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Watcher.kt
@@ -229,7 +229,7 @@ class Watcher(
                     previouslyCompiled = lastBuild?.partitionedModules?.flatMap { it.second }
                         ?: emptyList(),
                     runTask = runTask,
-                    moduleConfig = moduleConfig,
+                    moduleConfig = plugInBackendConfigs(moduleConfig),
                     cancelGroup = cancelGroup,
                     beforeStartTranslation = outputDirectoriesFree,
                     includeSnapshot = includeSnapshot,


### PR DESCRIPTION
- Tested with an external backend, where this was failing previously:

```
Watch starting build #0 at 2026-03-06T19:01:44.840Z
Finished build #0 in 3.588s
Watch starting build #1 at 2026-03-06T19:02:07.253Z
Finished build #1 in 329.622ms
Watch starting build #2 at 2026-03-06T19:02:36.885Z
Finished build #2 in 223.697ms
```