### PR TITLE
cli/repl: Fix importing from within repl

### DIFF
--- a/cli/src/test/kotlin/lang/temper/cli/repl/ReplTest.kt
+++ b/cli/src/test/kotlin/lang/temper/cli/repl/ReplTest.kt
@@ -1150,15 +1150,19 @@ class ReplTest {
             fs.write(filePath("config.temper.md"), "# hello".toByteArray())
             fs.write(
                 filePath("src.temper"),
-                """export let message(): String { "Hello, World!" }""".toByteArray(),
+                """
+                    |export class Message(public text: String) {
+                    |  public static hello: Message = new Message("Hello, World!");
+                    |}
+                """.trimMargin().toByteArray(),
             )
         }
         repl.processLine("""help("${AvailableImports.NAME}")""")
         assertPendingContains(
             Regex("""║hello *║/ *║let \{...} = import\("hello//"\); *║"""),
         )
-        repl.processLine("""let { message } = import("hello")""")
-        repl.processLine("""console.log(message())""")
+        repl.processLine("""let { Message } = import("hello")""")
+        repl.processLine("""console.log(Message.hello.text)""")
         assertPending(
             """
                 |interactive#1: void

--- a/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
@@ -290,7 +290,7 @@ class Interpreter(
     ): PartialResult = interpretTree(ast, env, interpMode, mayWrapEnvironment = mayWrapEnvironment)
 
     /**
-     * All recursive interpret calls MUST happen via this method so that we can keep breadcrumbs
+     * All recursive `interpret` calls MUST happen via this method so that we can keep breadcrumbs
      * and step counters up to date.
      */
     internal fun interpretEdge(
@@ -437,7 +437,7 @@ class Interpreter(
 
         val evaluation: InProgressEvaluation
         if (im == InterpMode.Full && yieldedAt != null) {
-            check(bodyOwner is TransientUserFunction) // yieldedAt is null for other variant
+            check(bodyOwner is TransientUserFunction) // yieldedAt is `null` for the other variant
             evaluation = yieldedAt
             bodyOwner.yieldedAt = null
         } else {
@@ -519,7 +519,7 @@ class Interpreter(
                         //     while (true) {}; 42             USE even though never reached.
                         // We can't determine statically if a function call or loop
                         // always/never/sometimes halts, so if we're ever to optimize anything out of
-                        // blocks we just optimistically assume that all terminal nodes are reached
+                        // blocks, we just optimistically assume that all terminal nodes are reached
                         // and that any code that is optimized using this will not run if the preceding
                         // does not halt.
                         fun lookThrough(cf: ControlFlow): Boolean = when (cf) {

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -128,7 +128,7 @@ fun prepareBuild(
 fun plugInBackendConfigs(
     moduleConfig: ModuleConfig,
     backends: List<BackendId> = supportedBackends,
-): ModuleConfig = ModuleConfig(
+): ModuleConfig = moduleConfig.copy(
     moduleCustomizeHook = { module, isNew ->
         moduleConfig.moduleCustomizeHook.customize(module, isNew)
         for (backendId in backends) {


### PR DESCRIPTION
Recent changes to Build.kt lost the mayRun bit which broke importing in the REPL.

This commit fixes the root problem: deriving one ModuleConfig from another.

And it changes a ReplTest case to read a static property which holds a class instance, something that is unlikely to work unless modules imported by the REPL are going through RuntimeEmulationStage.