### PR TITLE
fix: reset for-loop variable on each iteration in Rust async state machine

### DIFF
--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/ConvertCoroutineToControlFlow.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/ConvertCoroutineToControlFlow.kt
@@ -564,8 +564,14 @@ internal fun convertCoroutineToControlFlow(
                 if (declName != null && declName in namesToExtract) {
                     val extractWhole = when (initial) {
                         null -> true
-                        // If it's a simple function or value, pull the whole thing out.
-                        is FunTree, is ValueLeaf -> true
+                        // If it's a named function, pull the whole thing out.
+                        is FunTree -> true
+                        // For simple values, extract just the declaration and leave
+                        // the initializer in the case body.  If the declaration site
+                        // is inside a loop, the assignment needs to re-execute on
+                        // each iteration.  Leaving it in the case is safe even
+                        // outside loops—it just runs once when the case is entered.
+                        is ValueLeaf -> false
                         else -> false
                     }
 

--- a/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
@@ -2906,8 +2906,8 @@ class TmpLBackendTest {
             |        }
             |        let fn__0(): SafeGenerator<Empty> {
             |          var caseIndex#0: Int32 = 0;
-            |          @QName("test-library/foo.i=") var i__0: Int32 = 1;
-            |          @QName("test-library/foo.j=") var j__0: Int32 = 2;
+            |          @QName("test-library/foo.i=") var i__0: Int32 = 0;
+            |          @QName("test-library/foo.j=") var j__0: Int32 = 0;
             |          @QName("test-library/foo.helper()") let helper__0(): Void {
             |            var t#0: String = "" + nym`+#67`(i__0, j__0);
             |            ConsoleLog#0(console#0, t#0);
@@ -2918,6 +2918,8 @@ class TmpLBackendTest {
             |            caseIndex#0 = -1;
             |            when (caseIndexLocal#0) {
             |              0 -> do {
+            |                i__0 = 1;
+            |                j__0 = 2;
             |                @QName("test-library/foo.k=") var k__0: Int32 = 3;
             |                j__0 = nym`+#67`(j__0, 1);
             |                k__0 = nym`+#67`(k__0, 1);


### PR DESCRIPTION
Fixes #378

When a `for (var i = 0; ...)` loop is inside a while loop and the for body contains an `await`, the Rust backend's coroutine-to-state-machine transformation extracts the variable declaration to a persistent struct field but drops the initializer from the case body. This means `i = 0` only runs once (at generator creation), so the inner loop silently never executes after the first outer iteration.

The fix: don't extract the initializer for ValueLeaf (simple value) declarations. Extract just the declaration to persistent storage, and leave the `i = 0` assignment in the state machine case body so it re-executes every time the case is entered.

Before:
  persistent: `var i: Int = 0`   (runs once)
  case body:  (nothing)

After:
  persistent: `var i: Int`      (declaration only)
  case body: `i = 0`            (runs on each case entry)

This is safe for non-loop declarations too — the assignment just runs once when the case is entered, same as before.

Minimal reproduction (pure Temper, no deps):

```
  while (outerCount < 3) {
    outerCount = outerCount + 1;
    for (var i = 0; i < items.length; ++i) {
      totalLoopBodyRuns = totalLoopBodyRuns + 1;
      await resolved();
    }
  }
```

JS (correct): total loop body runs: 9

Rust before:  total loop body runs: 3

Rust after:   total loop body runs: 9

All existing be-rust and be-js tests pass.