### PR TITLE
Avoid parse fail on old luas

### DIFF
--- a/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
+++ b/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
@@ -1196,7 +1196,7 @@ do
                 if last_digit_value ~= 0 then
                     last_digit_value = base - last_digit_value
                 end
-                local negatable = (num + last_digit_value) // base
+                local negatable = temper_int.int_div(num + last_digit_value, base)
                 local digit_index = last_digit_value + 1
                 local last_digit = string_sub(digits, digit_index, digit_index)
                 return "-" .. temper_tostring(-negatable, base) .. last_digit
@@ -1205,7 +1205,7 @@ do
             end
         elseif num >= base then
             local mod = num % base + 1
-            return temper_tostring(math_floor(num // base), base) .. string_sub(digits, mod, mod)
+            return temper_tostring(temper_int.int_div(num, base), base) .. string_sub(digits, mod, mod)
         else
             local mod = num % base + 1
             return string_sub(digits, mod, mod)

--- a/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/intnew.lua
+++ b/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/intnew.lua
@@ -68,6 +68,11 @@ local function int64_toint32unsafe(n)
     return result
 end
 
+-- Simple int floor div.
+function temper.int_div(a, b)
+    return a // b
+end
+
 -- Int32
 
 function temper.int32_add(a, b)

--- a/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/intold.lua
+++ b/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/intold.lua
@@ -169,6 +169,11 @@ local function trunc(x)
     return result
 end
 
+-- Simple int floor div.
+function temper.int_div(a, b)
+    return math.floor(a / b)
+end
+
 -- Int32
 
 function temper.int32_add(a, b)


### PR DESCRIPTION
- This doesn't actually fix the int shifty funtest on old luas, but from manual testing, I *can* run the int limits funtest without crashing on both luajit and lua 5.2 (but not 5.1, but maybe that was an existing issue?) with these changes.
- Before these changes, old luas don't run at all for any funtest
- Here's the error on plain 5.1:

```lua
C:\Users\tjpal\Apps\lua-5.1.5_Win64_bin\lua5.1.exe: .\temper-core/intold.lua:38: attempt to call field 'trunc' (a nil value)
stack traceback:
        .\temper-core/intold.lua:38: in function 'rshift'
        .\temper-core/intold.lua:64: in function 'int32_mul_parts'
        .\temper-core/intold.lua:199: in function 'int32_mul'
        .\work\init.lua:10: in main chunk
        [C]: ?
```