### PR TITLE
Finish changing and testing near maybe

### DIFF
--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
@@ -318,7 +318,7 @@ public final class Core {
         double rel = relTol == null ? 1e-9 : relTol;
         double abs = absTol == null ? 0.0 : absTol;
         double margin = Math.max(Math.max(Math.abs(x), Math.abs(y)) * rel, abs);
-        return Math.abs(x - y) < margin;
+        return Math.abs(x - y) <= margin;
     }
 
     /**

--- a/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
+++ b/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
@@ -429,7 +429,7 @@ function temper.float64_near(x, y, rel_tol, abs_tol)
     abs_tol = temper.null_to_nil(abs_tol) or 0.0
     local scale = temper.float64_max(temper.float64_abs(x), temper.float64_abs(y))
     local margin = temper.float64_max(scale * rel_tol, abs_tol)
-    return temper.float64_abs(x - y) < margin
+    return temper.float64_abs(x - y) <= margin
 end
 
 function temper.float64_round(x)

--- a/be-rust/src/commonMain/resources/lang/temper/be/rust/temper-core/src/float64.rs
+++ b/be-rust/src/commonMain/resources/lang/temper/be/rust/temper-core/src/float64.rs
@@ -44,7 +44,7 @@ pub fn near(x: f64, y: f64, rel_tol: Option<f64>, abs_tol: Option<f64>) -> bool 
     let rel_tol = rel_tol.unwrap_or(1e-9);
     let abs_tol = abs_tol.unwrap_or(0.0);
     let margin = (x.abs().max(y.abs()) * rel_tol).max(abs_tol);
-    (x - y).abs() < margin
+    (x - y).abs() <= margin
 }
 
 pub fn rem(x: f64, y: f64) -> Result<f64> {

--- a/frontend/src/commonMain/resources/implicits/Implicits.temper
+++ b/frontend/src/commonMain/resources/implicits/Implicits.temper
@@ -1581,7 +1581,7 @@ export class Float64 extends Equatable {
     absTol: builtins.Float64 = 0.0,
   ): builtins.Boolean {
     let margin = (content.abs().max(other.abs()) * relTol).max(absTol);
-    (content - other).abs() < margin
+    (content - other).abs() <= margin
   }
 
   @connected("Float64::round")

--- a/functional-test-suite/src/commonMain/resources/types/float/ops/ops.temper.md
+++ b/functional-test-suite/src/commonMain/resources/types/float/ops/ops.temper.md
@@ -77,8 +77,11 @@ But also a bit of testing of `near` params.
 We have both `relTol` and `absTol` tolerance options, in that order. Either or
 both can be specified, although we try only one or the other here.
 
-    console.log("one.near(one + 0.1, absTol = 0.11): ${
-      one.near(one + 0.1, null, 0.11).toString()
+    console.log("one.near(one + 0.25, absTol = 0.25): ${
+      one.near(one + 0.25, null, 0.25).toString()
+    }");
+    console.log("one.near(one + 0.1 + 1e-9, absTol = 0.1): ${
+      one.near(one + 0.1 + 1e-9, null, 0.1).toString()
     }");
     console.log("one.near(one - 0.1, absTol = 0.11): ${
       one.near(one - 0.1, null, 0.11).toString()
@@ -127,7 +130,8 @@ one.sinh(): ✅
 (three * pi / four).tan(): ✅
 one.tanh(): ✅
 one.near(one + 0.1): false
-one.near(one + 0.1, absTol = 0.11): true
+one.near(one + 0.25, absTol = 0.25): true
+one.near(one + 0.1 + 1e-9, absTol = 0.1): false
 one.near(one - 0.1, absTol = 0.11): true
 ten.near(ten + 0.1, absTol = 0.011): false
 ten.near(ten + 0.1, relTol = 0.011): true


### PR DESCRIPTION
- I think this adds the backends that weren't already updated to `<=` for `Float64::near`
- Also adjust funtest to check for an edge case
- I don't have set up to test all backends properly at the moment, but this passes on lua, interp, js, and rust, at least, I think