### PR TITLE
Adjust string template docs

### DIFF
--- a/build-user-docs/skeletal-docs/temper-docs/docs/reference/modules.md
+++ b/build-user-docs/skeletal-docs/temper-docs/docs/reference/modules.md
@@ -21,7 +21,7 @@ In Temper Markdown, the file starts out in comment mode. That is, the
 text of the document is a comment to the Temper compiler. Temper code
 goes inside code blocks:
 
-````md
+````tempermd
 # My Temper Markdown source file
 
 This is text. You can treat it as a document.

--- a/build-user-docs/skeletal-docs/temper-docs/docs/tutorial/05-builtin.md
+++ b/build-user-docs/skeletal-docs/temper-docs/docs/tutorial/05-builtin.md
@@ -219,6 +219,19 @@ $ raw"\d+\.\d+"
 interactive#0: "\\d+\\.\\d+"
 ```
 
+Triple-quotes like `"""` start a multiline string, then all whitespace and
+comments are ignored, and every line content beginning with any of the following
+continues the string:
+
+- `"` contributes string content automatically followed by a newline
+- `~` contibutes string content without a newline
+- `:` provides full Temper control flow
+- `//` or `/*` starts a comment
+
+If non-whitespace line content starts with any other than above, the string
+ends. This syntax allows control over indentation both inside and outside the
+string content:
+
 ```temper
 $ console.log(
     """
@@ -241,18 +254,7 @@ $ console.log(
 interactive#1: void
 ```
 
-Triple-quotes like `"""` start a multiline string, then all whitespace and
-comments are ignored, and every line content beginning with any of the following
-continues the string:
-
-- `"` contributes string content automatically followed by a newline
-- `~` contibutes string content without a newline
-- `:` provides full Temper control flow
-- `//` or `/*` starts a comment
-
-If non-whitespace line content starts with any other than above, the string
-ends. This syntax allows control over indentation both inside and outside the
-string content. Here's an example with control flow:
+Here's an example with control flow:
 
 ```temper
 $ ("""

--- a/build-user-docs/skeletal-docs/temper-docs/docs/tutorial/05-builtin.md
+++ b/build-user-docs/skeletal-docs/temper-docs/docs/tutorial/05-builtin.md
@@ -259,7 +259,7 @@ $ ("""
     :for (var i = 1; i < 100; i *= 2) {
       // Use `~` here to avoid trailing newline.
       // Use empty interpolation to provide trailing whitespace.
-      ~${i.toString()}, ${""}
+      ~${i}, ${}
     :}
     ~and so on
   )

--- a/docs/for-users/temper-docs/docs/reference/modules.md
+++ b/docs/for-users/temper-docs/docs/reference/modules.md
@@ -21,7 +21,7 @@ In Temper Markdown, the file starts out in comment mode. That is, the
 text of the document is a comment to the Temper compiler. Temper code
 goes inside code blocks:
 
-````md
+````tempermd
 # My Temper Markdown source file
 
 This is text. You can treat it as a document.

--- a/docs/for-users/temper-docs/docs/tutorial/05-builtin.md
+++ b/docs/for-users/temper-docs/docs/tutorial/05-builtin.md
@@ -219,6 +219,19 @@ $ raw"\d+\.\d+"
 interactive#0: "\\d+\\.\\d+"
 ```
 
+Triple-quotes like `"""` start a multiline string, then all whitespace and
+comments are ignored, and every line content beginning with any of the following
+continues the string:
+
+- `"` contributes string content automatically followed by a newline
+- `~` contibutes string content without a newline
+- `:` provides full Temper control flow
+- `//` or `/*` starts a comment
+
+If non-whitespace line content starts with any other than above, the string
+ends. This syntax allows control over indentation both inside and outside the
+string content:
+
 ```temper
 $ console.log(
     """
@@ -241,18 +254,7 @@ $ console.log(
 interactive#1: void
 ```
 
-Triple-quotes like `"""` start a multiline string, then all whitespace and
-comments are ignored, and every line content beginning with any of the following
-continues the string:
-
-- `"` contributes string content automatically followed by a newline
-- `~` contibutes string content without a newline
-- `:` provides full Temper control flow
-- `//` or `/*` starts a comment
-
-If non-whitespace line content starts with any other than above, the string
-ends. This syntax allows control over indentation both inside and outside the
-string content. Here's an example with control flow:
+Here's an example with control flow:
 
 ```temper
 $ ("""

--- a/docs/for-users/temper-docs/docs/tutorial/05-builtin.md
+++ b/docs/for-users/temper-docs/docs/tutorial/05-builtin.md
@@ -259,7 +259,7 @@ $ ("""
     :for (var i = 1; i < 100; i *= 2) {
       // Use `~` here to avoid trailing newline.
       // Use empty interpolation to provide trailing whitespace.
-      ~${i.toString()}, ${""}
+      ~${i}, ${}
     :}
     ~and so on
   )


### PR DESCRIPTION
- Also change a tempermd block to tempermd. Here's before:

<img width="1214" height="1044" alt="image" src="https://github.com/user-attachments/assets/6743f294-c204-442d-bd5b-8558d2ee67c6" />

And after:

<img width="1214" height="1044" alt="image" src="https://github.com/user-attachments/assets/7b3c838a-cf98-4dfa-8194-c4efdd0007a0" />

- This fixes highlighting for the indented code. I still don't address untagged triple-quote in pygments, but this still feels like an improvement overall.
- Both still have an unclosed string, but that's fixed in #374