### PR TITLE
Support empty rust enums; test mutual recursion

### DIFF
--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -296,7 +296,6 @@ class RustTranslator(
         // If we use a separate pre-naming stage for be-rust, this might matter less.
         decls@ for (topLevel in module.topLevels) {
             when (topLevel) {
-                is TmpL.TypeDeclaration -> {} // TODO
                 is TmpL.ModuleFunctionDeclaration -> {
                     decls[topLevel.name.name] = DeclInfo(topLevel, typeFrom = topLevel.sig)
                 }
@@ -974,7 +973,7 @@ class RustTranslator(
         ).toItem().also { moduleItems.add(it) }
         // Implement traits including AnyValue.
         val typeRef = id.makeTypeRef(generics)
-        implTraits(pos, decl, typeRef, generics) // , enumId)
+        implTraits(pos, decl, typeRef, generics)
         Rust.Call(
             pos,
             callee = "temper_core".toKeyId(pos).extendWith("impl_any_value_trait_for_interface!"),

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -60,6 +60,7 @@ import lang.temper.type2.ValueFormalKind
 import lang.temper.type2.hackMapOldStyleToNew
 import lang.temper.type2.withNullity
 import lang.temper.type2.withType
+import lang.temper.value.DeclTree
 import lang.temper.value.TBoolean
 import lang.temper.value.TClass
 import lang.temper.value.TClosureRecord
@@ -295,6 +296,7 @@ class RustTranslator(
         // If we use a separate pre-naming stage for be-rust, this might matter less.
         decls@ for (topLevel in module.topLevels) {
             when (topLevel) {
+                is TmpL.TypeDeclaration -> {} // TODO
                 is TmpL.ModuleFunctionDeclaration -> {
                     decls[topLevel.name.name] = DeclInfo(topLevel, typeFrom = topLevel.sig)
                 }
@@ -698,7 +700,6 @@ class RustTranslator(
         decl: TmpL.TypeDeclaration,
         typeRef: Rust.Type,
         generics: List<Rust.GenericParam>,
-        enumId: Rust.Id? = null,
     ): MutableList<Rust.Type> {
         val supTypes = mutableListOf<Rust.Type>()
         val selfParams = listOf(Rust.RefType(pos, type = "self".toKeyId(pos)))
@@ -709,6 +710,7 @@ class RustTranslator(
         sups@ for ((subShape, sup) in decl.typeShape.allInterfaces(allowStart = true)) {
             // Only handle type shapes, and only unique ones.
             val supShape = (sup.definition as? TypeShape) ?: continue@sups
+            val supDecl = supShape.stayLeaf?.incoming?.source as? DeclTree
             // For sealed enums, this picks an arbitrary winner. TODO Allow diamonds and/or check against them earlier.
             handledSups.add(supShape.name) || continue@sups
             // Handle this one.
@@ -730,7 +732,7 @@ class RustTranslator(
                 type = typeRef.deepCopy(),
                 items = buildList {
                     // Some need as_enum.
-                    if (supShape.sealedSubTypes != null || enumId != null) {
+                    if (supDecl?.parts?.metadataSymbolMap?.contains(sealedTypeSymbol) == true) {
                         // The sub shape must be a member of the sealed sub types if the Temper was legal.
                         // TODO Qualified path, not just name.
                         val enumId = supName.suffixed(ENUM_NAME_SUFFIX)
@@ -972,7 +974,7 @@ class RustTranslator(
         ).toItem().also { moduleItems.add(it) }
         // Implement traits including AnyValue.
         val typeRef = id.makeTypeRef(generics)
-        implTraits(pos, decl, typeRef, generics, enumId)
+        implTraits(pos, decl, typeRef, generics) // , enumId)
         Rust.Call(
             pos,
             callee = "temper_core".toKeyId(pos).extendWith("impl_any_value_trait_for_interface!"),

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -698,6 +698,7 @@ class RustTranslator(
         decl: TmpL.TypeDeclaration,
         typeRef: Rust.Type,
         generics: List<Rust.GenericParam>,
+        enumId: Rust.Id? = null,
     ): MutableList<Rust.Type> {
         val supTypes = mutableListOf<Rust.Type>()
         val selfParams = listOf(Rust.RefType(pos, type = "self".toKeyId(pos)))
@@ -729,7 +730,7 @@ class RustTranslator(
                 type = typeRef.deepCopy(),
                 items = buildList {
                     // Some need as_enum.
-                    if (supShape.sealedSubTypes != null) {
+                    if (supShape.sealedSubTypes != null || enumId != null) {
                         // The sub shape must be a member of the sealed sub types if the Temper was legal.
                         // TODO Qualified path, not just name.
                         val enumId = supName.suffixed(ENUM_NAME_SUFFIX)
@@ -971,7 +972,7 @@ class RustTranslator(
         ).toItem().also { moduleItems.add(it) }
         // Implement traits including AnyValue.
         val typeRef = id.makeTypeRef(generics)
-        implTraits(pos, decl, typeRef, generics)
+        implTraits(pos, decl, typeRef, generics, enumId)
         Rust.Call(
             pos,
             callee = "temper_core".toKeyId(pos).extendWith("impl_any_value_trait_for_interface!"),
@@ -1377,7 +1378,7 @@ class RustTranslator(
             pos,
             id = enumId,
             generics = generics,
-            items = decl.typeShape.sealedSubTypes!!.map { sub ->
+            items = (decl.typeShape.sealedSubTypes ?: listOf()).map { sub ->
                 val subId = translateTypeOutName(sub.name).toId(pos)
                 val subType = subId.deepCopy().makeTypeRef(generics)
                 Rust.EnumItemTuple(pos, id = subId, fields = listOf(Rust.TupleField(pos, type = subType)))

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -849,6 +849,7 @@ class RustBackendTest {
                 |let maybe: Apple? = thing;
                 |let nope = thing as Carrot;
                 |let alsoNope = maybe as Carrot;
+                |export sealed interface AllAlone {}
             """.trimMargin(),
             rust = """
                 |pub (crate) fn init() -> temper_core::Result<()> {
@@ -932,6 +933,33 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Carrot, [Apple]);
+                |pub enum AllAloneEnum {}
+                |pub trait AllAloneTrait: temper_core::AsAnyValue + temper_core::AnyValueTrait + std::marker::Send + std::marker::Sync {
+                |    fn as_enum(& self) -> AllAloneEnum;
+                |    fn clone_boxed(& self) -> AllAlone;
+                |}
+                |#[derive(Clone)]
+                |pub struct AllAlone(std::sync::Arc<dyn AllAloneTrait>);
+                |impl AllAlone {
+                |    pub fn new(selfish: impl AllAloneTrait + 'static) -> AllAlone {
+                |        AllAlone(std::sync::Arc::new(selfish))
+                |    }
+                |}
+                |impl AllAloneTrait for AllAlone {
+                |    fn as_enum(& self) -> AllAloneEnum {
+                |        AllAloneTrait::as_enum( & ( * self.0))
+                |    }
+                |    fn clone_boxed(& self) -> AllAlone {
+                |        AllAloneTrait::clone_boxed( & ( * self.0))
+                |    }
+                |}
+                |temper_core::impl_any_value_trait_for_interface!(AllAlone);
+                |impl std::ops::Deref for AllAlone {
+                |    type Target = dyn AllAloneTrait;
+                |    fn deref(& self) -> & Self::Target {
+                |        & ( * self.0)
+                |    }
+                |}
             """.trimMargin(),
         )
     }

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -849,7 +849,6 @@ class RustBackendTest {
                 |let maybe: Apple? = thing;
                 |let nope = thing as Carrot;
                 |let alsoNope = maybe as Carrot;
-                |export sealed interface AllAlone {}
             """.trimMargin(),
             rust = """
                 |pub (crate) fn init() -> temper_core::Result<()> {
@@ -933,33 +932,6 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Carrot, [Apple]);
-                |pub enum AllAloneEnum {}
-                |pub trait AllAloneTrait: temper_core::AsAnyValue + temper_core::AnyValueTrait + std::marker::Send + std::marker::Sync {
-                |    fn as_enum(& self) -> AllAloneEnum;
-                |    fn clone_boxed(& self) -> AllAlone;
-                |}
-                |#[derive(Clone)]
-                |pub struct AllAlone(std::sync::Arc<dyn AllAloneTrait>);
-                |impl AllAlone {
-                |    pub fn new(selfish: impl AllAloneTrait + 'static) -> AllAlone {
-                |        AllAlone(std::sync::Arc::new(selfish))
-                |    }
-                |}
-                |impl AllAloneTrait for AllAlone {
-                |    fn as_enum(& self) -> AllAloneEnum {
-                |        AllAloneTrait::as_enum( & ( * self.0))
-                |    }
-                |    fn clone_boxed(& self) -> AllAlone {
-                |        AllAloneTrait::clone_boxed( & ( * self.0))
-                |    }
-                |}
-                |temper_core::impl_any_value_trait_for_interface!(AllAlone);
-                |impl std::ops::Deref for AllAlone {
-                |    type Target = dyn AllAloneTrait;
-                |    fn deref(& self) -> & Self::Target {
-                |        & ( * self.0)
-                |    }
-                |}
             """.trimMargin(),
         )
     }
@@ -1692,6 +1664,8 @@ class RustBackendTest {
                 |export interface I {}
                 |export sealed interface Hi<T extends I> {}
                 |export class Lo<T extends I> extends Hi<T> {}
+                |// Piggyback a subtypeless sealed interface with a non-sealed supertype.
+                |export sealed interface AllAlone extends I {}
             """.trimMargin(),
             rust = """
                 |pub (crate) fn init() -> temper_core::Result<()> {
@@ -1773,6 +1747,38 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Lo<T>, [Hi<T>] where T: ITrait);
+                |pub enum AllAloneEnum {}
+                |pub trait AllAloneTrait: temper_core::AsAnyValue + temper_core::AnyValueTrait + std::marker::Send + std::marker::Sync + ITrait {
+                |    fn as_enum(& self) -> AllAloneEnum;
+                |    fn clone_boxed(& self) -> AllAlone;
+                |}
+                |#[derive(Clone)]
+                |pub struct AllAlone(std::sync::Arc<dyn AllAloneTrait>);
+                |impl AllAlone {
+                |    pub fn new(selfish: impl AllAloneTrait + 'static) -> AllAlone {
+                |        AllAlone(std::sync::Arc::new(selfish))
+                |    }
+                |}
+                |impl AllAloneTrait for AllAlone {
+                |    fn as_enum(& self) -> AllAloneEnum {
+                |        AllAloneTrait::as_enum( & ( * self.0))
+                |    }
+                |    fn clone_boxed(& self) -> AllAlone {
+                |        AllAloneTrait::clone_boxed( & ( * self.0))
+                |    }
+                |}
+                |impl ITrait for AllAlone {
+                |    fn clone_boxed(& self) -> I {
+                |        ITrait::clone_boxed( & ( * self.0))
+                |    }
+                |}
+                |temper_core::impl_any_value_trait_for_interface!(AllAlone);
+                |impl std::ops::Deref for AllAlone {
+                |    type Target = dyn AllAloneTrait;
+                |    fn deref(& self) -> & Self::Target {
+                |        & ( * self.0)
+                |    }
+                |}
             """.trimMargin(),
         )
     }

--- a/functional-test-suite/src/commonMain/resources/functions/as-values/as-values.temper.md
+++ b/functional-test-suite/src/commonMain/resources/functions/as-values/as-values.temper.md
@@ -36,3 +36,34 @@ Named functions can be stored in properties with a functional interface type.
 ```log
 Called from a method!
 ```
+
+## Mutual recursion detour
+
+Not sure where else we already test recursion, but here's some for now. And
+specifically, we want to ensure mutual recursion works.
+
+    console.log("Is 5 even? ${isEven(5)}");
+    console.log("Is 6 even? ${isEven(6)}");
+
+These only work for non-negative integers, but that's ok here.
+
+    let isEven(i: Int): Boolean {
+      if (i == 0) {
+        true
+      } else {
+        isOdd(i - 1)
+      }
+    }
+
+    let isOdd(i: Int): Boolean {
+      if (i == 0) {
+        false
+      } else {
+        isEven(i - 1)
+      }
+    }
+
+```log
+Is 5 even? false
+Is 6 even? true
+```

--- a/functional-test-suite/src/commonMain/resources/interfaces/property-members/property-members.temper.md
+++ b/functional-test-suite/src/commonMain/resources/interfaces/property-members/property-members.temper.md
@@ -81,3 +81,8 @@ Also because it's in the ballpark, test generic sealed interfaces here.
 ```log
 Sealed thing is foo.
 ```
+
+Also a sealed interface with no subtypes. This is just here to see if backends
+break. There's no way to instantiate one.
+
+    sealed interface AllAlone {}

--- a/functional-test-suite/src/commonMain/resources/interfaces/property-members/property-members.temper.md
+++ b/functional-test-suite/src/commonMain/resources/interfaces/property-members/property-members.temper.md
@@ -85,4 +85,6 @@ Sealed thing is foo.
 Also a sealed interface with no subtypes. This is just here to see if backends
 break. There's no way to instantiate one.
 
-    sealed interface AllAlone {}
+But do extend another non-sealed interface to ensure we also handle that.
+
+    sealed interface AllAlone extends I {}


### PR DESCRIPTION
- Fix RustTranslator crash on sealed interfaces without subtypes
- Funtest mutual recursion
- The two topics are unrelated, but I hadn't put cross-backend testing on mutual recursion anywhere, so I snuck that in for future testing