### PR TITLE
Help strings in byte buffer slices

### DIFF
--- a/be-java/build.gradle
+++ b/be-java/build.gradle
@@ -68,9 +68,9 @@ tasks.register("testJavaTemperCore", Exec) {
     workingDir = file("src/commonMain/resources/lang/temper/be/java/temper-core")
     if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
         // Effort needed for finding mvn on windows.
-        commandLine "cmd", "/c", "mvn", "test"
+        commandLine "cmd", "/c", "mvn", "-B", "test"
     } else {
-        commandLine "mvn", "test"
+        commandLine "mvn", "test", "-B"
     }
 }
 

--- a/be-java/build.gradle
+++ b/be-java/build.gradle
@@ -74,6 +74,6 @@ tasks.register("testJavaTemperCore", Exec) {
     }
 }
 
-tasks.named('test') {
-    dependsOn tasks.named('testJavaTemperCore')
+tasks.named("test") {
+    dependsOn tasks.named("testJavaTemperCore")
 }

--- a/be-java/build.gradle
+++ b/be-java/build.gradle
@@ -74,6 +74,6 @@ tasks.register("testJavaTemperCore", Exec) {
     }
 }
 
-tasks.named("test") {
+tasks.named("check") {
     dependsOn tasks.named("testJavaTemperCore")
 }

--- a/be-java/build.gradle
+++ b/be-java/build.gradle
@@ -63,3 +63,17 @@ kotlin {
         }
     }
 }
+
+tasks.register("testJavaTemperCore", Exec) {
+    workingDir = file("src/commonMain/resources/lang/temper/be/java/temper-core")
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+        // Effort needed for finding mvn on windows.
+        commandLine "cmd", "/c", "mvn", "test"
+    } else {
+        commandLine "mvn", "test"
+    }
+}
+
+tasks.named('test') {
+    dependsOn tasks.named('testJavaTemperCore')
+}

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/pom.xml
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/pom.xml
@@ -24,6 +24,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.2</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -114,6 +123,11 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
         <configuration/>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
       </plugin>
     </plugins>
   </build>

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
@@ -7,6 +7,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -423,6 +424,7 @@ public final class Core {
     /**
      * Encode a string into a section of a ByteBuffer.
      * The caller is responsible for knowing that the slice exists.
+     * Default to UTF8 for null decoder.
      */
     public static String decodeFromSlice(
         ByteBuffer source,
@@ -430,6 +432,9 @@ public final class Core {
         int sourceLength,
         CharsetDecoder decoder
     ) throws CharacterCodingException {
+        if (decoder == null) {
+            decoder = StandardCharsets.UTF_8.newDecoder();
+        }
         // Limit slice.
         int oldLimit = source.limit();
         int oldPosition = source.position();
@@ -449,6 +454,7 @@ public final class Core {
     /**
      * Encode a string into a section of a ByteBuffer, returning the number of bytes written.
      * The caller is responsible for knowing that the slice exists.
+     * Default to UTF8 for null encoder.
      */
     public static int encodeIntoSlice(
         String s,
@@ -458,6 +464,9 @@ public final class Core {
         CharsetEncoder encoder,
         byte padByte
     ) {
+        if (encoder == null) {
+            encoder = StandardCharsets.UTF_8.newEncoder();
+        }
         // Limit slice.
         int oldLimit = target.limit();
         int oldPosition = target.position();

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
@@ -1,6 +1,12 @@
 package temper.core;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -411,6 +417,67 @@ public final class Core {
             // Use error message similar to code point bounds message, which is checked elsewhere.
             // Focus on Unicode scalar value wording, because it might explain motive better than avoiding surrogates.
             throw new IllegalArgumentException(String.format("Not a valid Unicode scalar value: 0x%X", codePoint));
+        }
+    }
+
+    /**
+     * Encode a string into a section of a ByteBuffer.
+     * The caller is responsible for knowing that the slice exists.
+     */
+    public static String decodeFromSlice(
+        ByteBuffer source,
+        int sourceStart,
+        int sourceLength,
+        CharsetDecoder decoder
+    ) throws CharacterCodingException {
+        // Limit slice.
+        int oldLimit = source.limit();
+        int oldPosition = source.position();
+        source.position(sourceStart);
+        source.limit(sourceStart + sourceLength);
+        try {
+            // Decode.
+            decoder.reset();
+            return decoder.decode(source).toString();
+        } finally {
+            // Restore.
+            source.limit(oldLimit);
+            source.position(oldPosition);
+        }
+    }
+
+    /**
+     * Encode a string into a section of a ByteBuffer, returning the number of bytes written.
+     * The caller is responsible for knowing that the slice exists.
+     */
+    public static int encodeIntoSlice(
+        String s,
+        ByteBuffer target,
+        int targetStart,
+        int targetLength,
+        CharsetEncoder encoder,
+        byte padByte
+    ) {
+        // Limit slice.
+        int oldLimit = target.limit();
+        int oldPosition = target.position();
+        target.position(targetStart);
+        target.limit(targetStart + targetLength);
+        try {
+            // Encode.
+            encoder.reset();
+            CoderResult result = encoder.encode(CharBuffer.wrap(s), target, true);
+            encoder.flush(target);
+            // Pad.
+            int written = target.position() - targetStart;
+            while (target.hasRemaining()) {
+                target.put(padByte);
+            }
+            return written;
+        } finally {
+            // Restore.
+            target.limit(oldLimit);
+            target.position(oldPosition);
         }
     }
 

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/main/java/temper/core/Core.java
@@ -422,7 +422,7 @@ public final class Core {
     }
 
     /**
-     * Encode a string into a section of a ByteBuffer.
+     * Decode a string from a section of a ByteBuffer.
      * The caller is responsible for knowing that the slice exists.
      * Default to UTF8 for null decoder.
      */
@@ -438,9 +438,9 @@ public final class Core {
         // Limit slice.
         int oldLimit = source.limit();
         int oldPosition = source.position();
-        source.position(sourceStart);
-        source.limit(sourceStart + sourceLength);
         try {
+            source.position(sourceStart);
+            source.limit(sourceStart + sourceLength);
             // Decode.
             decoder.reset();
             return decoder.decode(source).toString();
@@ -470,9 +470,9 @@ public final class Core {
         // Limit slice.
         int oldLimit = target.limit();
         int oldPosition = target.position();
-        target.position(targetStart);
-        target.limit(targetStart + targetLength);
         try {
+            target.position(targetStart);
+            target.limit(targetStart + targetLength);
             // Encode.
             encoder.reset();
             CoderResult result = encoder.encode(CharBuffer.wrap(s), target, true);

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
@@ -5,8 +5,8 @@ import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.nio.charset.CoderResult;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,9 +27,18 @@ public class SliceCoderTest {
 
     @Test
     void decodeFromSliceInvalidSequence() {
-        ByteBuffer buffer = ByteBuffer.wrap(new byte[]{(byte) 0xFF}); // Invalid UTF-8
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[]{(byte)0xFF}); // Invalid UTF-8
         CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         assertThrows(CharacterCodingException.class, () -> Core.decodeFromSlice(buffer, 0, 1, decoder));
+    }
+
+    @Test
+    void decodeFromSliceLatin1() throws CharacterCodingException {
+        // 0xA3 in Latin-1 is '£'. In UTF-8, 0xA3 is an invalid start byte.
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[]{(byte)0xA3});
+        CharsetDecoder decoder = StandardCharsets.ISO_8859_1.newDecoder();
+        String result = Core.decodeFromSlice(buffer, 0, 1, decoder);
+        assertEquals("£", result, "Should decode correctly using Latin-1");
     }
 
     @Test
@@ -38,7 +47,7 @@ public class SliceCoderTest {
         String text = "ABC"; // 3 bytes in UTF-8
         CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         // Encode into a 5-byte slice at offset 2
-        int written = Core.encodeIntoSlice(text, buffer, 2, 5, encoder, (byte) '_');
+        int written = Core.encodeIntoSlice(text, buffer, 2, 5, encoder, (byte)'_');
         assertEquals(3, written);
         // Check actual buffer contents
         byte[] data = buffer.array();
@@ -54,9 +63,8 @@ public class SliceCoderTest {
     void encodeIntoSliceTruncation() {
         ByteBuffer buffer = ByteBuffer.allocate(5);
         String text = "Too Long String";
-        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         // Buffer limit of 2 bytes should stop the encoder
-        int written = Core.encodeIntoSlice(text, buffer, 0, 2, encoder, (byte) 0);
+        int written = Core.encodeIntoSlice(text, buffer, 0, 2, null, (byte)0);
         assertEquals(2, written);
         assertEquals(0, buffer.position());
     }
@@ -67,10 +75,9 @@ public class SliceCoderTest {
         // 😀 = 4 bytes (F0 9F 98 80)
         String text = "✨😀";
         ByteBuffer buffer = ByteBuffer.allocate(10);
-        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         // Slice of 5 bytes at offset 0
         // Result: "✨" (3 bytes) fits, "😀" (4 bytes) fails, 2 bytes padding
-        int written = Core.encodeIntoSlice(text, buffer, 0, 5, encoder, (byte) '_');
+        int written = Core.encodeIntoSlice(text, buffer, 0, 5, null, (byte)'_');
         assertEquals(3, written, "Only the 3-byte emoji should have been written");
         // Validate buffer contents
         byte[] data = buffer.array();
@@ -82,5 +89,26 @@ public class SliceCoderTest {
         assertEquals((byte) '_', data[3]);
         assertEquals((byte) '_', data[4]);
         assertEquals(0, buffer.position(), "State should be restored");
+    }
+
+    @Test
+    void encodeIntoSliceLatin1() {
+        // '£' (Sterling) exists in Latin-1 (0xA3)
+        // '✨' (Sparkles) DOES NOT exist in Latin-1
+        String text = "£✨";
+        ByteBuffer buffer = ByteBuffer.allocate(5);
+        // Create a Latin-1 encoder
+        // By default, it will throw an exception for the emoji unless configured otherwise
+        CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder()
+            .onUnmappableCharacter(CodingErrorAction.REPLACE)
+            .replaceWith(new byte[]{(byte)'?'});
+        int written = Core.encodeIntoSlice(text, buffer, 0, 5, encoder, (byte)'.');
+        // '£' becomes 0xA3 (1 byte)
+        // '✨' is unmappable, becomes '?' (1 byte)
+        assertEquals(2, written, "Should have written 2 bytes (one real, one replacement)");
+        byte[] data = buffer.array();
+        assertEquals((byte)0xA3, data[0], "Latin-1 encoding for £");
+        assertEquals((byte)'?', data[1], "Replacement char for unmappable emoji");
+        assertEquals((byte)'.', data[2], "Padding");
     }
 }

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
@@ -67,6 +67,8 @@ public class SliceCoderTest {
         int written = Core.encodeIntoSlice(text, buffer, 0, 2, null, (byte)0);
         assertEquals(2, written);
         assertEquals(0, buffer.position());
+        assertEquals('T', (char)buffer.get(0));
+        assertEquals('o', (char)buffer.get(1));
     }
 
     @Test
@@ -82,12 +84,13 @@ public class SliceCoderTest {
         // Validate buffer contents
         byte[] data = buffer.array();
         // First 3 bytes should be the Sparkles emoji
-        assertEquals((byte) 0xE2, data[0]);
-        assertEquals((byte) 0x9C, data[1]);
-        assertEquals((byte) 0xA8, data[2]);
+        assertEquals((byte)0xE2, data[0]);
+        assertEquals((byte)0x9C, data[1]);
+        assertEquals((byte)0xA8, data[2]);
         // Last 2 bytes should be padding because 😀 didn't fit
-        assertEquals((byte) '_', data[3]);
-        assertEquals((byte) '_', data[4]);
+        assertEquals((byte)'_', data[3]);
+        assertEquals((byte)'_', data[4]);
+        assertEquals((byte)'_', data[4]);
         assertEquals(0, buffer.position(), "State should be restored");
     }
 

--- a/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
+++ b/be-java/src/commonMain/resources/lang/temper/be/java/temper-core/src/test/java/temper/core/SliceCoderTest.java
@@ -1,0 +1,86 @@
+package temper.core;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.CoderResult;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SliceCoderTest {
+    @Test
+    void decodeFromSliceSuccess() throws CharacterCodingException {
+        String input = "Hello World";
+        ByteBuffer buffer = ByteBuffer.wrap("###Hello World###".getBytes(StandardCharsets.UTF_8));
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        // Decode only "Hello World" (offset 3, length 11)
+        String result = Core.decodeFromSlice(buffer, 3, 11, decoder);
+        assertEquals("Hello World", result);
+        assertEquals(0, buffer.position(), "Position should be restored");
+        assertEquals(buffer.capacity(), buffer.limit(), "Limit should be restored");
+    }
+
+    @Test
+    void decodeFromSliceInvalidSequence() {
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[]{(byte) 0xFF}); // Invalid UTF-8
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        assertThrows(CharacterCodingException.class, () -> Core.decodeFromSlice(buffer, 0, 1, decoder));
+    }
+
+    @Test
+    void encodeIntoSliceWithPadding() {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        String text = "ABC"; // 3 bytes in UTF-8
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+        // Encode into a 5-byte slice at offset 2
+        int written = Core.encodeIntoSlice(text, buffer, 2, 5, encoder, (byte) '_');
+        assertEquals(3, written);
+        // Check actual buffer contents
+        byte[] data = buffer.array();
+        assertEquals('A', (char)data[2]);
+        assertEquals('B', (char)data[3]);
+        assertEquals('C', (char)data[4]);
+        assertEquals('_', (char)data[5]); // Padding
+        assertEquals('_', (char)data[6]); // Padding
+        assertEquals(0, buffer.position(), "State must be restored");
+    }
+
+    @Test
+    void encodeIntoSliceTruncation() {
+        ByteBuffer buffer = ByteBuffer.allocate(5);
+        String text = "Too Long String";
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+        // Buffer limit of 2 bytes should stop the encoder
+        int written = Core.encodeIntoSlice(text, buffer, 0, 2, encoder, (byte) 0);
+        assertEquals(2, written);
+        assertEquals(0, buffer.position());
+    }
+
+    @Test
+    void encodeIntoSlicePartialMultibyteFit() {
+        // ✨ = 3 bytes (E2 9C A8)
+        // 😀 = 4 bytes (F0 9F 98 80)
+        String text = "✨😀";
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+        // Slice of 5 bytes at offset 0
+        // Result: "✨" (3 bytes) fits, "😀" (4 bytes) fails, 2 bytes padding
+        int written = Core.encodeIntoSlice(text, buffer, 0, 5, encoder, (byte) '_');
+        assertEquals(3, written, "Only the 3-byte emoji should have been written");
+        // Validate buffer contents
+        byte[] data = buffer.array();
+        // First 3 bytes should be the Sparkles emoji
+        assertEquals((byte) 0xE2, data[0]);
+        assertEquals((byte) 0x9C, data[1]);
+        assertEquals((byte) 0xA8, data[2]);
+        // Last 2 bytes should be padding because 😀 didn't fit
+        assertEquals((byte) '_', data[3]);
+        assertEquals((byte) '_', data[4]);
+        assertEquals(0, buffer.position(), "State should be restored");
+    }
+}


### PR DESCRIPTION
- Support external and possible future needs for easy string storage in struct slices
- Allow encoding into and decoding from byte buffer slices in single statements and/or expressions
- Run direct mvn tests for be-java temper-core
- The unit tests are mostly written by AI, but they look reasonable to me