### PR TITLE
List backend docs in menu

### DIFF
--- a/build-user-docs/skeletal-docs/temper-docs/docs/reference/backend.md
+++ b/build-user-docs/skeletal-docs/temper-docs/docs/reference/backend.md
@@ -1,3 +1,7 @@
+---
+title: Writing a New Backend
+---
+
 # So you want to write a Temper backend
 
 ## Notice

--- a/build-user-docs/skeletal-docs/temper-docs/mkdocs.yml
+++ b/build-user-docs/skeletal-docs/temper-docs/mkdocs.yml
@@ -126,6 +126,8 @@ nav:
     - reference/syntax.md
     - reference/modules.md
     - Target Language List: reference/target-languages.md
+    - reference/backend.md
+    - reference/out-grammar.md
   - Blog:
     - blog/index.md
   - 'Legalese':

--- a/docs/for-users/temper-docs/docs/reference/backend.md
+++ b/docs/for-users/temper-docs/docs/reference/backend.md
@@ -1,3 +1,7 @@
+---
+title: Writing a New Backend
+---
+
 # So you want to write a Temper backend
 
 ## Notice

--- a/docs/for-users/temper-docs/mkdocs.yml
+++ b/docs/for-users/temper-docs/mkdocs.yml
@@ -126,6 +126,8 @@ nav:
     - reference/syntax.md
     - reference/modules.md
     - Target Language List: reference/target-languages.md
+    - reference/backend.md
+    - reference/out-grammar.md
   - Blog:
     - blog/index.md
   - 'Legalese':


### PR DESCRIPTION
- Add menu entries that I missed in #415
- From `./gradlew serveUserDocs`:

<img width="1717" height="1108" alt="image" src="https://github.com/user-attachments/assets/7a878fc2-7783-4ac5-8738-a995ddcb8eb3" />