### PR TITLE
Fix external bullets

### DIFF
--- a/build-user-docs/skeletal-docs/temper-docs/docs/reference/backend.md
+++ b/build-user-docs/skeletal-docs/temper-docs/docs/reference/backend.md
@@ -121,14 +121,14 @@ modules can be under these directories. For example:
 - be-data/
 - ...
 - external/
-  - my-other-project/
-    - be-mylang/
-      - build.gradle
-      - ...
-    - be-myotherlang/
-      - build.gradle
-      - ...
-  - my-yet-other-project/
+    - my-other-project/
+        - be-mylang/
+            - build.gradle
+            - ...
+        - be-myotherlang/
+            - build.gradle
+            - ...
+    - my-yet-other-project/
 - ...
 - settings.gradle
 

--- a/docs/for-users/temper-docs/docs/reference/backend.md
+++ b/docs/for-users/temper-docs/docs/reference/backend.md
@@ -121,14 +121,14 @@ modules can be under these directories. For example:
 - be-data/
 - ...
 - external/
-  - my-other-project/
-    - be-mylang/
-      - build.gradle
-      - ...
-    - be-myotherlang/
-      - build.gradle
-      - ...
-  - my-yet-other-project/
+    - my-other-project/
+        - be-mylang/
+            - build.gradle
+            - ...
+        - be-myotherlang/
+            - build.gradle
+            - ...
+    - my-yet-other-project/
 - ...
 - settings.gradle
 


### PR DESCRIPTION
- Learned that mkdocs wants bullets indented by 4, not 2
- Old on github:
  <img width="1501" height="881" alt="image" src="https://github.com/user-attachments/assets/bbae494e-16f9-4485-9dfe-d06b20d9e615" />
- Old on mkdocs:
  <img width="1274" height="981" alt="image" src="https://github.com/user-attachments/assets/328b4465-27cd-469a-a5aa-a97b05a0338d" />
- New on mkdocs:
  <img width="1275" height="1005" alt="image" src="https://github.com/user-attachments/assets/dd138db4-eeef-417a-bac8-3483bb31f0d4" />
