### PR TITLE
Refine imu and testing; add release note

### DIFF
--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
@@ -299,7 +299,11 @@ class PyTranslator(
 
         var needsGeneric = true
         val needsProto = t.kind == TmpL.TypeDeclarationKind.Interface
-        t.superTypes.forEach { nominalType ->
+        t.superTypes.forEach superTypes@{ nominalType ->
+            when (nominalType.typeName.sourceDefinition) {
+                WellKnownTypes.imuTypeDefinition, WellKnownTypes.partialImuTypeDefinition -> return@superTypes
+                else -> {}
+            }
             if (nominalType.params.isNotEmpty()) {
                 needsGeneric = false
             }
@@ -371,7 +375,7 @@ class PyTranslator(
         ): List<Py.Stmt> = buildList {
             // TODO: substitute python parameter names for TmpL names
             // See be-java's javadoc(...) helpers.
-            val fnDocumentation = s.documentation?.prettyPleaseHelp()
+            val fnDocumentation = s.documentation.prettyPleaseHelp()
             if (fnDocumentation != null) {
                 add(translateDocString(fnDocumentation, s.pos))
             }
@@ -1116,7 +1120,7 @@ class PyTranslator(
         // TODO We also need to have renamed globals for rare cases of conflict with named args.
         // TODO Is the above still a valid concern?
         // TODO Why don't method bodies currently include declareReferences?
-        val documentation = func.documentation?.prettyPleaseHelp()
+        val documentation = func.documentation.prettyPleaseHelp()
         if (documentation != null) {
             add(translateDocString(documentation, func.pos))
         }
@@ -1572,6 +1576,7 @@ class PyTranslator(
                 is TmpL.ConnectedToTypeName -> null
             }
             when (typeDefinition) {
+                // TODO Translate Imu, PartialImu
                 WellKnownTypes.emptyTypeDefinition -> Py.Tuple(type.pos, emptyList())
                 WellKnownTypes.listTypeDefinition,
                 WellKnownTypes.listedTypeDefinition,

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -3133,7 +3133,10 @@ class RustTranslator(
         // Otherwise look up well-known types or use the user-defined type.
         return when (def.sourceLocation) {
             ImplicitsCodeLocation -> when (def) {
-                WellKnownTypes.anyValueTypeDefinition -> OutName(ANY_NAME, def.name)
+                WellKnownTypes.anyValueTypeDefinition,
+                WellKnownTypes.imuTypeDefinition,
+                WellKnownTypes.partialImuTypeDefinition,
+                -> OutName(ANY_NAME, def.name)
                 WellKnownTypes.booleanTypeDefinition -> OutName("bool", def.name)
                 WellKnownTypes.denseBitVectorTypeDefinition -> OutName(DENSE_BIT_VECTOR_NAME, def.name)
                 WellKnownTypes.dequeTypeDefinition -> OutName(DEQUE_NAME, def.name)

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
@@ -121,7 +121,8 @@ class ImuChecker(
             }
         }
         var passes = true
-        if (presumedImu.isEmpty()) {
+        if (presumedImu.isEmpty() && typeShape.abstractness == Abstractness.Concrete) {
+            // Class with no type parameters has no reason to be PartialImu.
             passes = false
             logSink.log(
                 ImuMessage.PartialImuTypeHasNoTypeParameters,

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
@@ -143,9 +143,21 @@ class ImuCheckerTest {
                 |extends PartialImuInterfaceOneArg<T> & PartialImuInterfaceTwoArgs<T, Neither> {}
                 |-> PartialImu interface BadPartialImuDeepInterface2 could have Imu parameters but it extends PartialImuInterfaceTwoArgs__21<T__38, Neither__5> which cannot be Imu because Neither__5 is not!
                 |
+                |BadImuClassWithImuDeepInterface:
+                |class BadImuClassWithImuDeepInterface extends ImuDeepInterface {
+                |  public n: Neither;
+                |}
+                |-> Class BadImuClassWithImuDeepInterface extends Imu but property n has type Neither__5 which is not Imu!
+                |
+                |BadPartialImuClassWithPartialImuDeepInterface:
+                |class BadPartialImuClassWithPartialImuDeepInterface<T> extends PartialImuDeepInterface1<T> {
+                |  public n: Neither;
+                |}
+                |-> Class BadPartialImuClassWithPartialImuDeepInterface extends PartialImu but property n has type Neither__5 which is not Imu!
+                |
                 |BadPartialImuViaUpcast:
                 |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
-                |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be Imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__19<List<U__41>> because T__40 is not Imu!
+                |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be Imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__19<List<U__45>> because T__44 is not Imu!
                 |
                 |BadImuClassUsingPartialImu:
                 |class BadImuClassUsingPartialImu<T> extends Imu {
@@ -156,7 +168,7 @@ class ImuCheckerTest {
                 |
                 |BadPartialImuInterfaceHidesParam:
                 |interface BadPartialImuInterfaceHidesParam<T> extends PartialImuInterfaceOneArg<ListBuilder<T>> {}
-                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have Imu parameters but it extends PartialImuInterfaceOneArg__19<ListBuilder<T__48>> which cannot be Imu because ListBuilder<T__48> is not!
+                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have Imu parameters but it extends PartialImuInterfaceOneArg__19<ListBuilder<T__52>> which cannot be Imu because ListBuilder<T__52> is not!
             """.trimMargin().trimEnd(),
             got.trimEnd(),
         )
@@ -212,6 +224,14 @@ class ImuCheckerTest {
             |
             |interface BadPartialImuDeepInterface2<T>
             |extends PartialImuInterfaceOneArg<T> & PartialImuInterfaceTwoArgs<T, Neither> {}
+            |
+            |interface ImuDeepInterface extends Imu {}
+            |class BadImuClassWithImuDeepInterface extends ImuDeepInterface {
+            |  public n: Neither;
+            |}
+            |class BadPartialImuClassWithPartialImuDeepInterface<T> extends PartialImuDeepInterface1<T> {
+            |  public n: Neither;
+            |}
             |
             |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
             |

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
@@ -132,16 +132,16 @@ class ImuCheckerTest {
                 |  public p: T; // ok
                 |  public q: ListBuilder<T>; // not imu under any parameterization
                 |}
-                |-> Class BadPartialImuClass extends PartialImu but property q has type ListBuilder<T__34> which is not Imu!
+                |-> Class BadPartialImuClass extends PartialImu but property q has type ListBuilder<T__35> which is not Imu!
                 |
                 |BadPartialImuDeepInterface1:
                 |interface BadPartialImuDeepInterface1<T> extends PartialImuInterfaceTwoArgs<T, Neither> {}
-                |-> PartialImu interface BadPartialImuDeepInterface1 could have Imu parameters but it extends PartialImuInterfaceTwoArgs__21<T__36, Neither__5> which cannot be Imu because Neither__5 is not!
+                |-> PartialImu interface BadPartialImuDeepInterface1 could have Imu parameters but it extends PartialImuInterfaceTwoArgs__22<T__37, Neither__5> which cannot be Imu because Neither__5 is not!
                 |
                 |BadPartialImuDeepInterface2:
                 |interface BadPartialImuDeepInterface2<T>
                 |extends PartialImuInterfaceOneArg<T> & PartialImuInterfaceTwoArgs<T, Neither> {}
-                |-> PartialImu interface BadPartialImuDeepInterface2 could have Imu parameters but it extends PartialImuInterfaceTwoArgs__21<T__38, Neither__5> which cannot be Imu because Neither__5 is not!
+                |-> PartialImu interface BadPartialImuDeepInterface2 could have Imu parameters but it extends PartialImuInterfaceTwoArgs__22<T__39, Neither__5> which cannot be Imu because Neither__5 is not!
                 |
                 |BadImuClassWithImuDeepInterface:
                 |class BadImuClassWithImuDeepInterface extends ImuDeepInterface {
@@ -157,7 +157,7 @@ class ImuCheckerTest {
                 |
                 |BadPartialImuViaUpcast:
                 |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
-                |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be Imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__19<List<U__45>> because T__44 is not Imu!
+                |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be Imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<List<U__46>> because T__45 is not Imu!
                 |
                 |BadImuClassUsingPartialImu:
                 |class BadImuClassUsingPartialImu<T> extends Imu {
@@ -168,7 +168,7 @@ class ImuCheckerTest {
                 |
                 |BadPartialImuInterfaceHidesParam:
                 |interface BadPartialImuInterfaceHidesParam<T> extends PartialImuInterfaceOneArg<ListBuilder<T>> {}
-                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have Imu parameters but it extends PartialImuInterfaceOneArg__19<ListBuilder<T__52>> which cannot be Imu because ListBuilder<T__52> is not!
+                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have Imu parameters but it extends PartialImuInterfaceOneArg__20<ListBuilder<T__53>> which cannot be Imu because ListBuilder<T__53> is not!
             """.trimMargin().trimEnd(),
             got.trimEnd(),
         )
@@ -206,6 +206,7 @@ class ImuCheckerTest {
             |  public p: List<T>;
             |}
             |
+            |interface PartialImuInterfaceNoTypeArgs extends PartialImu {}
             |class BadPartialImuNoTypeArgs extends PartialImu {}
             |class PartialImuDirectClass<T> extends PartialImu {
             |  public p: T;

--- a/release-notes/snippets/imu.md
+++ b/release-notes/snippets/imu.md
@@ -1,0 +1,64 @@
+### Imu and PartialImu tag interfaces
+
+The following interfaces are now built into Temper. These tag interfaces are
+commitments on the part of any type that extends them:
+
+- *Imu* - Any type extending *Imu* must be deeply immutable with not even any
+  internal state changes allowed. Built-in *Imu* types include *String*,
+  *Int32*, and *Boolean*, among others.
+- *PartialImu* - Any type extending *PartialImu* is also immutable when actual
+  type arguments are deeply immutable. Built-in *PartialImu* types include
+  *List* and *Map*.
+
+Immutable types will allow for safe transfer across threads or for compile-time
+evaluation, among other possible applications. Most target languages don't have
+a way to explicitly state immutability, but it's possible these tags can affect
+translation in some cases.
+
+*Imu* and *PartialImu* are checked by the Temper compiler. For example, the
+following declarations are legal:
+
+```temper inert
+// Imu tag is valid because all properties are Imu.
+// And `List<Int>` is Imu because *Int* is Imu.
+class SomeValues(
+  public text: String,
+  public numbers: List<Int>,
+) extends Imu {}
+
+// PartialImu is valid because this type is Imu if *T* is Imu.
+class SummarizedItems<T>(
+  public items: List<T>,
+  public summary: T,
+) extends PartialImu {}
+
+// Imu is valid because *T* is constrained.
+interface PropHolder<T extends Imu> extends Imu {
+  public prop: T;
+}
+
+// And Imu is still valid here because all tags follow rules.
+class SummarizedItemsHolder(
+  public prop: SummarizedItems<String>,
+) extends PropHolder<SummarizedItems<String>> {}
+```
+
+But the following are illegal:
+
+```temper inert
+// No commitment tag here, so legal but not Imu.
+class NoCommitment {}
+
+// Compiler error because *NoCommitment* isn't Imu.
+class BadImuClass(
+  public things: List<NoCommitment>,
+) extends Imu {}
+
+// Compiler error because *reassignable* is `var`.
+class BadImuClassBecauseVar<T>(
+  public var reassignable: List<T>,
+) extends PartialImu {}
+```
+
+This is just a sampling of the rules which enforce *Imu* and *PartialImu*
+tagging.


### PR DESCRIPTION
- Allow unparameterized PartialImu interfaces, although still not classes
- Add tests for locally bad classes with deeply inherited imu
- Add a release note snippet for imu