### PR TITLE
fix(IfTransform): when with is-Type arms now infers arm_types | Void

### DIFF
--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/TypeStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/TypeStageTest.kt
@@ -2394,6 +2394,49 @@ class TypeStageTest {
             |}
         """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )
+
+    // https://github.com/temperlang/temper/issues/427
+    // A `when` expression without `else` whose arms return String should assign
+    // the return variable on each arm (String | Void), not initialise the whole
+    // result to void (Void). Before the IfTransform fix, the body was
+    // `let return__0; return__0 = void` — the arms were never assigned.
+    @Test
+    fun whenIsTypeNoElse() = assertModuleAtStage(
+        input = "when (c) { is String -> \"yes\"; is Int -> \"no\"; }",
+        moduleResultNeeded = true,
+        stage = Stage.Type,
+        want = """
+        {
+          type: {
+            body:
+            ```
+            let return__0;
+            var t#0, t#1;
+            if (!false) {
+              t#0 = is(c, String)
+            } else {
+              t#0 = false
+            };
+            if (t#0) {
+              return__0 = "yes"
+            } else {
+              if (!false) {
+                t#1 = is(c, Int32)
+              } else {
+                t#1 = false
+              };
+              if (t#1) {
+                return__0 = "no"
+              } else {
+                return__0 = void
+              }
+            };
+
+            ```
+          }
+        }
+        """,
+    )
 }
 
 private object ImpureIgnoreFn : NamedBuiltinFun, CallableValue {

--- a/functional-test-suite/src/commonMain/resources/control-flow/when-is-type-inference/when-is-type-inference.temper.md
+++ b/functional-test-suite/src/commonMain/resources/control-flow/when-is-type-inference/when-is-type-inference.temper.md
@@ -1,0 +1,75 @@
+# `when` with `is TypeName` arms infers the arm type
+
+A `when` expression whose arms use `is TypeName` patterns should produce
+a type reflecting the common type of the arms, not `Void`.
+
+Regression test for https://github.com/temperlang/temper/issues/427
+
+## Setup — sealed interface with two variants
+
+    export sealed interface Shape {}
+    export class Circle() extends Shape {}
+    export class Square() extends Shape {}
+
+## Case 1: arms return String
+
+`when` without `else` should still type as `String | Void`, not `Void`.
+The workaround (if-else narrowing) is shown alongside for comparison.
+
+    export let describe(s: Shape): String {
+      when (s) {
+        is Circle -> "circle";
+        is Square -> "square";
+      }
+    }
+
+    export let describeIfElse(s: Shape): String {
+      if (s is Circle) { "circle" } else { "square" }
+    }
+
+    test("when arms return String — tail expression") {
+      assert(describe(new Circle()) == "circle") { "when: circle" };
+      assert(describe(new Square()) == "square") { "when: square" };
+      assert(describeIfElse(new Circle()) == "circle") { "if-else: circle" };
+      assert(describeIfElse(new Square()) == "square") { "if-else: square" };
+    }
+
+## Case 2: arms return sealed-interface subtypes
+
+    export sealed interface Status {}
+    export class Active()                    extends Status {}
+    export class Done(public winner: String) extends Status {}
+    export class Drawn()                     extends Status {}
+
+    export let classify(code: Int): Status {
+      when (code) {
+        0    -> new Active();
+        1    -> new Done("white");
+        else -> new Drawn();
+      }
+    }
+
+    test("when arms return sealed subtypes — inferred as common interface") {
+      assert(classify(0) is Active) { "active" };
+      assert(classify(1) is Done)   { "done" };
+      assert(classify(2) is Drawn)  { "drawn" };
+    }
+
+## Case 3: nested sealed dispatch
+
+    export sealed interface Expr {}
+    export class Lit(public value: Int) extends Expr {}
+    export class Neg(public inner: Expr) extends Expr {}
+
+    export let eval(e: Expr): Int {
+      when (e) {
+        is Lit -> e.value;
+        is Neg -> -eval(e.inner);
+      }
+    }
+
+    test("recursive when dispatch over sealed Expr") {
+      assert(eval(new Lit(5)) == 5)         { "lit 5" };
+      assert(eval(new Neg(new Lit(3))) == -3) { "neg(lit 3)" };
+      assert(eval(new Neg(new Neg(new Lit(7)))) == 7) { "neg(neg(lit 7))" };
+    }

--- a/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
@@ -218,21 +218,20 @@ internal object IfTransform : ControlFlowTransform("if") {
                     }
                 }
 
-                // `if` chains that don't end in an `else` should be typed as Void.
-                // See LoopTransform comments on typing as for the problems with control-flow
-                // constructs that start with a condition and which don't reliably follow it
-                // with a typeable tree.
-                if (controlFlow != null && !hasFinalElse) {
-                    controlFlow = ControlFlow.StmtBlock(
-                        controlFlow.pos,
-                        listOf(
-                            controlFlow,
-                            ControlFlow.Stmt(
-                                macroCursor.referenceToVoid(controlFlow.pos.rightEdge),
-                            ),
-                        ),
-                    )
-                }
+                // NOTE: we do NOT append a trailing void here for the !hasFinalElse case.
+                // The innermost synthetic else clause (built above at lines 190-195 when
+                // hasFinalElse = false) already inserts a void reference for the "fell
+                // through all arms" path. A trailing sequential void after the if-chain is
+                // redundant and harmful: findUnsetTerminalExpressions picks it up as the
+                // terminal expression on every exit path, causing the entire when expression
+                // to be typed as Void regardless of what the arms return.
+                //
+                // Without the trailing void, findUnsetTerminalExpressions finds the arm body
+                // expressions as terminals alongside the innermost else void, so the inferred
+                // type is arm_types | Void instead of Void alone. This is the correct
+                // behaviour for `when` expressions whose arms use `is TypeName` patterns.
+                //
+                // See: https://github.com/temperlang/temper/issues/427
 
                 controlFlow?.let { ControlFlowSubflow(it) }
             }


### PR DESCRIPTION
Fixes #427.

## What this changes

Removes 14 lines from `IfTransform.complicate` (`interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt`, lines 221–234) that wrapped the nested if-chain for a `when` without `else` in a trailing `ControlFlow.StmtBlock([if-chain, Stmt(void)])`.

## Why it was wrong

Because `StmtBlock.wrap` is idempotent (a StmtBlock input is returned unchanged), `ControlFlowTransform.invoke` set the `StructuredFlow` to this `StmtBlock([If(...), Stmt(void)])`. `forwardMaximalPaths` walked exit paths and always found the trailing `Stmt(void)` as the terminal expression, never the arm bodies. `MakeResultsExplicit` then initialised the result variable to `void` unconditionally, and the Typer inferred `Void` for the entire expression.

## Why the fix works

The `void` inserted at lines 190–195 in the innermost synthetic else clause already marks the fallthrough ("no arm matched") exit path. Without the outer sequential `Stmt(void)`, `forwardMaximalPaths` finds the arm body expressions as terminal expressions alongside the innermost void. The inferred type becomes `arm_types | Void` instead of `Void`.

## Before / after

**Before** — `when (c) { is String -> "yes"; is Int -> "no"; }` at Type stage:
```
let return__0;
return__0 = void
```

**After**:
```
let return__0;
if (t#0) {
  return__0 = "yes"
} else {
  if (t#1) {
    return__0 = "no"
  } else {
    return__0 = void   ← fallthrough; no exhaustiveness checking yet
  }
}
```

## Scope

This does not implement exhaustiveness checking for sealed types. The fallthrough `void` path remains. Functions with an explicit non-void return type still require an `else` arm (or `else -> bubble()`) to compile without error. That is a separate feature.

## Tests

- `TypeStageTest.whenIsTypeNoElse` — regression test asserting the new Type stage output
- `control-flow/when-is-type-inference/when-is-type-inference.temper.md` — functional tests asserting runtime correctness of `describe`, `classify`, and recursive sealed dispatch
- Full frontend test suite passes (`./gradlew :frontend:jvmTest`)

Found while porting [chess9](https://github.com/notactuallytreyanastasio/chess9) to Temper.