### PR TITLE
Avoid hiding mut classes under `partialImu` supers

### DIFF
--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
@@ -45,7 +45,7 @@ enum class ImuMessage(
     ),
     ExpectedImuType("Expected imu type but got %s"),
     DeepPartialImuTypeDoesNotImplySuperTypeImu(
-        "PartialImu interface %s's type parameter <%s> would not be imu" +
+        "PartialImu type %s's type parameter <%s> would not be imu" +
             " when cast to its effectively Imu super-type %s because %s is not imu",
     ),
     DeepPartialImuTypeCanNeverBeImu(
@@ -119,16 +119,16 @@ class ImuChecker(
             getSuperTypeTree(superType).hasSymbol(partialImuSymbol)
         }
 
-        val presumedImu = buildSet {
-            typeShape.formals.mapNotNullTo(this) { formal ->
-                when {
-                    // All partialImu supers need to reference this formal to be able to presume imu.
-                    // Otherwise, even for classes, we could upcast and hide mutability.
-                    partialImuSupers.all { it.references(formal) } -> MkType2(formal).get()
-                    else -> null
-                }
+        // Split formals into those referenced by all partialImuSupers and those that aren't.
+        // For those that aren't, we could track all non-referencers, but one is good enough.
+        val (presumedImu, novelFormals) = typeShape.formals
+            .map { formal -> MkType2(formal).get() to partialImuSupers.find { !it.references(formal) } }
+            .partition { (_, partialImuSuperWithoutFormal) -> partialImuSuperWithoutFormal == null }
+            .let { (presumedImu, novelFormals) ->
+                buildSet { presumedImu.mapTo(this) { it.first } } to
+                    @Suppress("UNCHECKED_CAST")
+                    (novelFormals.toMap() as Map<TypeParamRef, Type2>)
             }
-        }
         var passes = true
         if (typeShape.formals.isEmpty() && typeShape.metadata.containsKey(partialImuSymbol)) {
             // Types with no type parameters have no reason to be directly tagged partialImu.
@@ -146,6 +146,7 @@ class ImuChecker(
                 typeName,
                 partialImuSymbol,
                 presumedImu = presumedImu,
+                novelFormals = novelFormals,
             )
         ) {
             passes = false
@@ -279,6 +280,8 @@ class ImuChecker(
         typeName: TemperName,
         claimed: Symbol,
         presumedImu: Set<Type2> = emptySet(),
+        /** Formals that could be presumed imu except they're absent in partialImu supertypes. */
+        novelFormals: Map<TypeParamRef, Type2> = emptyMap(),
     ): Boolean {
         var passes = true
         val contravariantTypeParameters = contravariantTypeParametersFor(typeShape)
@@ -293,6 +296,7 @@ class ImuChecker(
                             contravariantTypeParameters,
                             claimed,
                             presumedImu = presumedImu,
+                            novelFormals = novelFormals,
                         )
                     ) {
                         passes = false
@@ -309,6 +313,8 @@ class ImuChecker(
         contravariantTypeParameters: Set<TypeDefinition>,
         claimed: Symbol,
         presumedImu: Set<Type2> = emptySet(),
+        /** Formals that could be presumed imu except they're absent in partialImu supertypes. */
+        novelFormals: Map<TypeParamRef, Type2> = emptyMap(),
     ): Boolean {
         var passes = true
         val propertyName = ParsedName(property.symbol.text)
@@ -330,11 +336,23 @@ class ImuChecker(
                         ?: property.declarationPos
                     logSink.log(ImuMessage.ExpectedImuType, typePos, listOf(nonImuPart))
                 }
-                logSink.log(
-                    ImuMessage.ImuClassPropertyIsNotImu,
-                    property.declarationPos,
-                    listOf(typeName, claimed.text, propertyName, staticType),
-                )
+                when (val hiddenMutSuper = novelFormals[nonImuPart]) {
+                    null -> logSink.log(
+                        ImuMessage.ImuClassPropertyIsNotImu,
+                        property.declarationPos,
+                        listOf(typeName, claimed.text, propertyName, staticType),
+                    )
+                    else -> logSink.log(
+                        ImuMessage.DeepPartialImuTypeDoesNotImplySuperTypeImu,
+                        property.declarationPos,
+                        listOf(
+                            typeName,
+                            nonImuPart.definition.diagnosticTypeName,
+                            hiddenMutSuper,
+                            nonImuPart,
+                        ),
+                    )
+                }
             } else {
                 val contravariantParamUsed = mentionedInType(staticType, contravariantTypeParameters)
                 if (contravariantParamUsed != null) {

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
@@ -130,8 +130,8 @@ class ImuChecker(
             }
         }
         var passes = true
-        if (typeShape.formals.isEmpty() && typeShape.abstractness == Abstractness.Concrete) {
-            // Class with no type parameters has no reason to be PartialImu.
+        if (typeShape.formals.isEmpty() && typeShape.metadata.containsKey(partialImuSymbol)) {
+            // Types with no type parameters have no reason to be directly tagged partialImu.
             passes = false
             logSink.log(
                 ImuMessage.PartialImuTypeHasNoTypeParameters,

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/ImuChecker.kt
@@ -19,6 +19,7 @@ import lang.temper.type.WellKnownTypes
 import lang.temper.type2.MkType2
 import lang.temper.type2.SuperTypeTree2
 import lang.temper.type2.Type2
+import lang.temper.type2.TypeParamRef
 import lang.temper.type2.hackMapOldStyleToNew
 import lang.temper.value.DeclTree
 import lang.temper.value.Tree
@@ -111,13 +112,25 @@ class ImuChecker(
     }
 
     private fun checkPartialImu(typeShape: TypeShape, typeName: TemperName): Boolean {
+        // Find the shallowest super-types that are partial imu.
+        val partialImuSupers = typeShape.superTypes.map { superType ->
+            hackMapOldStyleToNew(superType)
+        }.filter { superType ->
+            getSuperTypeTree(superType).hasSymbol(partialImuSymbol)
+        }
+
         val presumedImu = buildSet {
-            typeShape.formals.mapTo(this) {
-                MkType2(it).get()
+            typeShape.formals.mapNotNullTo(this) { formal ->
+                when {
+                    // All partialImu supers need to reference this formal to be able to presume imu.
+                    // Otherwise, even for classes, we could upcast and hide mutability.
+                    partialImuSupers.all { it.references(formal) } -> MkType2(formal).get()
+                    else -> null
+                }
             }
         }
         var passes = true
-        if (presumedImu.isEmpty() && typeShape.abstractness == Abstractness.Concrete) {
+        if (typeShape.formals.isEmpty() && typeShape.abstractness == Abstractness.Concrete) {
             // Class with no type parameters has no reason to be PartialImu.
             passes = false
             logSink.log(
@@ -139,20 +152,15 @@ class ImuChecker(
         }
 
         when (typeShape.abstractness) {
+            // If we require the same for classes as for interfaces, we can't distinguish
+            // backed properties vs computed-only things.
             Abstractness.Concrete -> {}
             Abstractness.Abstract -> {
                 // For an interface type, look at its super-types that are partial imu and make sure that
                 // its parameterizations of them imply consistently
                 // They all need to have effectively imu types when type bindings are imu.
 
-                // Find the shallowest super-types that are partial imu.
-                val partialImuSupers = typeShape.superTypes.map { superType ->
-                    hackMapOldStyleToNew(superType)
-                }.filter { superType ->
-                    getSuperTypeTree(superType).hasSymbol(partialImuSymbol)
-                }
-
-                // For each of them, the type projection has to imply consistency when up-cast.
+                // For each of partialImu super, the type projection has to imply consistency when up-cast.
                 for (partialImuSuper in partialImuSupers) {
                     // Check consistency of down-casting.
                     //
@@ -428,3 +436,12 @@ private fun mentionedInType(type: Type2, typeDefs: Set<TypeDefinition>): TypeDef
 
 private val TypeDefinition.diagnosticTypeName: TemperName get() =
     (this.name as? ResolvedParsedName)?.baseName ?: this.name
+
+private fun Type2.references(formal: TypeFormal): Boolean {
+    return bindings.any { binding ->
+        when (binding) {
+            is TypeParamRef -> binding.definition == formal
+            else -> binding.references(formal)
+        }
+    }
+}

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
@@ -123,6 +123,10 @@ class ImuCheckerTest {
                 |}
                 |-> Class BadImuContravariant claims imu but property p: List<T__13> uses contravariant type T__13!
                 |
+                |BadPartialImuInterfaceNoTypeArgs:
+                |interface BadPartialImuInterfaceNoTypeArgs {}
+                |-> Type BadPartialImuInterfaceNoTypeArgs claims partialImu but has no type parameters!
+                |
                 |BadPartialImuNoTypeArgs:
                 |class BadPartialImuNoTypeArgs {}
                 |-> Type BadPartialImuNoTypeArgs claims partialImu but has no type parameters!
@@ -164,8 +168,8 @@ class ImuCheckerTest {
                 |-> PartialImu interface BadPartialImuViaUpcast2's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<U__49> because T__48 is not imu!
                 |
                 |BadPartialImuViaUpcast3:
-                |interface BadPartialImuViaUpcast3<T> extends PartialImuInterfaceNoTypeArgs {}
-                |-> PartialImu interface BadPartialImuViaUpcast3's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceNoTypeArgs__16 because T__51 is not imu!
+                |interface BadPartialImuViaUpcast3<T> extends BadPartialImuInterfaceNoTypeArgs {}
+                |-> PartialImu interface BadPartialImuViaUpcast3's type parameter <T> would not be imu when cast to its effectively Imu super-type BadPartialImuInterfaceNoTypeArgs__16 because T__51 is not imu!
                 |
                 |BadPartialImuClassViaUpcast:
                 |class BadPartialImuClassViaUpcast<T, U>(
@@ -175,7 +179,7 @@ class ImuCheckerTest {
                 |-> Class BadPartialImuClassViaUpcast claims partialImu but property prop has type T__56 which is not imu!
                 |
                 |BadPartialImuClassViaUpcast2:
-                |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
+                |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends BadPartialImuInterfaceNoTypeArgs {}
                 |-> Class BadPartialImuClassViaUpcast2 claims partialImu but property prop has type T__59 which is not imu!
                 |
                 |BadImuClassUsingPartialImu:
@@ -225,7 +229,7 @@ class ImuCheckerTest {
             |  public p: List<T>;
             |}
             |
-            |@partialImu interface PartialImuInterfaceNoTypeArgs {}
+            |@partialImu interface BadPartialImuInterfaceNoTypeArgs {}
             |@partialImu class BadPartialImuNoTypeArgs {}
             |@partialImu class PartialImuDirectClass<T> {
             |  public p: T;
@@ -255,16 +259,16 @@ class ImuCheckerTest {
             |
             |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
             |interface BadPartialImuViaUpcast2<T, U> extends PartialImuInterfaceOneArg<U> {}
-            |interface BadPartialImuViaUpcast3<T> extends PartialImuInterfaceNoTypeArgs {}
-            |interface PartialImuViaUpcast4<@imu T> extends PartialImuInterfaceNoTypeArgs {}
-            |@imu class ImuClassThatWouldBeOk(public prop: PartialImuInterfaceNoTypeArgs) {}
+            |interface BadPartialImuViaUpcast3<T> extends BadPartialImuInterfaceNoTypeArgs {}
+            |interface PartialImuViaUpcast4<@imu T> extends BadPartialImuInterfaceNoTypeArgs {}
+            |@imu class ImuClassThatWouldBeOk(public prop: BadPartialImuInterfaceNoTypeArgs) {}
             |class BadPartialImuClassViaUpcast<T, U>(
             |  public prop: T,
             |  public prop2: U,
             |) extends PartialImuInterfaceOneArg<List<U>> {}
-            |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
-            |class PartialImuClassViaUpcast<@imu T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
-            |class PartialImuClassViaUpcast2<T> extends PartialImuInterfaceNoTypeArgs {
+            |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends BadPartialImuInterfaceNoTypeArgs {}
+            |class PartialImuClassViaUpcast<@imu T>(public prop: T) extends BadPartialImuInterfaceNoTypeArgs {}
+            |class PartialImuClassViaUpcast2<T> extends BadPartialImuInterfaceNoTypeArgs {
             |  public hi(thing: T): T { thing }
             |}
             |class PartialImuClassViaUpcast3<T> extends ImuDeepInterface {
@@ -281,6 +285,7 @@ class ImuCheckerTest {
             |  public p: List<Neither>;
             |}
             |interface BadPartialImuInterfaceHidesParam<T> extends PartialImuInterfaceOneArg<ListBuilder<T>> {}
+            |interface TechnicallyPartialImuInterfaceNoTypeArgs extends PartialImuInterfaceOneArg<String> {}
         """.trimMargin()
 
         private val typesByName: Map<String, TypeShape>

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
@@ -161,26 +161,26 @@ class ImuCheckerTest {
                 |
                 |BadPartialImuViaUpcast:
                 |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
-                |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<List<U__46>> because T__45 is not imu!
+                |-> PartialImu type BadPartialImuViaUpcast's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<List<U__46>> because T__45 is not imu!
                 |
                 |BadPartialImuViaUpcast2:
                 |interface BadPartialImuViaUpcast2<T, U> extends PartialImuInterfaceOneArg<U> {}
-                |-> PartialImu interface BadPartialImuViaUpcast2's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<U__49> because T__48 is not imu!
+                |-> PartialImu type BadPartialImuViaUpcast2's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<U__49> because T__48 is not imu!
                 |
                 |BadPartialImuViaUpcast3:
                 |interface BadPartialImuViaUpcast3<T> extends BadPartialImuInterfaceNoTypeArgs {}
-                |-> PartialImu interface BadPartialImuViaUpcast3's type parameter <T> would not be imu when cast to its effectively Imu super-type BadPartialImuInterfaceNoTypeArgs__16 because T__51 is not imu!
+                |-> PartialImu type BadPartialImuViaUpcast3's type parameter <T> would not be imu when cast to its effectively Imu super-type BadPartialImuInterfaceNoTypeArgs__16 because T__51 is not imu!
                 |
                 |BadPartialImuClassViaUpcast:
                 |class BadPartialImuClassViaUpcast<T, U>(
                 |  public prop: T,
                 |  public prop2: U,
                 |) extends PartialImuInterfaceOneArg<List<U>> {}
-                |-> Class BadPartialImuClassViaUpcast claims partialImu but property prop has type T__56 which is not imu!
+                |-> PartialImu type BadPartialImuClassViaUpcast's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<List<U__57>> because T__56 is not imu!
                 |
                 |BadPartialImuClassViaUpcast2:
                 |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends BadPartialImuInterfaceNoTypeArgs {}
-                |-> Class BadPartialImuClassViaUpcast2 claims partialImu but property prop has type T__59 which is not imu!
+                |-> PartialImu type BadPartialImuClassViaUpcast2's type parameter <T> would not be imu when cast to its effectively Imu super-type BadPartialImuInterfaceNoTypeArgs__16 because T__59 is not imu!
                 |
                 |BadImuClassUsingPartialImu:
                 |class BadImuClassUsingPartialImu<T> {

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/typestage/ImuCheckerTest.kt
@@ -159,6 +159,25 @@ class ImuCheckerTest {
                 |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
                 |-> PartialImu interface BadPartialImuViaUpcast's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<List<U__46>> because T__45 is not imu!
                 |
+                |BadPartialImuViaUpcast2:
+                |interface BadPartialImuViaUpcast2<T, U> extends PartialImuInterfaceOneArg<U> {}
+                |-> PartialImu interface BadPartialImuViaUpcast2's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceOneArg__20<U__49> because T__48 is not imu!
+                |
+                |BadPartialImuViaUpcast3:
+                |interface BadPartialImuViaUpcast3<T> extends PartialImuInterfaceNoTypeArgs {}
+                |-> PartialImu interface BadPartialImuViaUpcast3's type parameter <T> would not be imu when cast to its effectively Imu super-type PartialImuInterfaceNoTypeArgs__16 because T__51 is not imu!
+                |
+                |BadPartialImuClassViaUpcast:
+                |class BadPartialImuClassViaUpcast<T, U>(
+                |  public prop: T,
+                |  public prop2: U,
+                |) extends PartialImuInterfaceOneArg<List<U>> {}
+                |-> Class BadPartialImuClassViaUpcast claims partialImu but property prop has type T__56 which is not imu!
+                |
+                |BadPartialImuClassViaUpcast2:
+                |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
+                |-> Class BadPartialImuClassViaUpcast2 claims partialImu but property prop has type T__59 which is not imu!
+                |
                 |BadImuClassUsingPartialImu:
                 |class BadImuClassUsingPartialImu<T> {
                 |  public p: List<Neither>;
@@ -168,7 +187,7 @@ class ImuCheckerTest {
                 |
                 |BadPartialImuInterfaceHidesParam:
                 |interface BadPartialImuInterfaceHidesParam<T> extends PartialImuInterfaceOneArg<ListBuilder<T>> {}
-                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have imu parameters but it extends PartialImuInterfaceOneArg__20<ListBuilder<T__53>> which cannot be imu because ListBuilder<T__53> is not!
+                |-> PartialImu interface BadPartialImuInterfaceHidesParam could have imu parameters but it extends PartialImuInterfaceOneArg__20<ListBuilder<T__74>> which cannot be imu because ListBuilder<T__74> is not!
             """.trimMargin().trimEnd(),
             got.trimEnd(),
         )
@@ -235,6 +254,22 @@ class ImuCheckerTest {
             |}
             |
             |interface BadPartialImuViaUpcast<T, U> extends PartialImuInterfaceOneArg<List<U>> {}
+            |interface BadPartialImuViaUpcast2<T, U> extends PartialImuInterfaceOneArg<U> {}
+            |interface BadPartialImuViaUpcast3<T> extends PartialImuInterfaceNoTypeArgs {}
+            |interface PartialImuViaUpcast4<@imu T> extends PartialImuInterfaceNoTypeArgs {}
+            |@imu class ImuClassThatWouldBeOk(public prop: PartialImuInterfaceNoTypeArgs) {}
+            |class BadPartialImuClassViaUpcast<T, U>(
+            |  public prop: T,
+            |  public prop2: U,
+            |) extends PartialImuInterfaceOneArg<List<U>> {}
+            |class BadPartialImuClassViaUpcast2<T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
+            |class PartialImuClassViaUpcast<@imu T>(public prop: T) extends PartialImuInterfaceNoTypeArgs {}
+            |class PartialImuClassViaUpcast2<T> extends PartialImuInterfaceNoTypeArgs {
+            |  public hi(thing: T): T { thing }
+            |}
+            |class PartialImuClassViaUpcast3<T> extends ImuDeepInterface {
+            |  public hi(thing: T): T { thing }
+            |}
             |
             |@imu class ImuClassUsesPartialImu {
             |  public p: PartialImuInterfaceOneArg<ImuOneProperty>;


### PR DESCRIPTION
- Maybe finish imu checking for now
- Test more that we can't hide mut when upcasting interfaces
- Add checks against upcast hiding mut for classes also, which allowing cases where no backed property applies
- Flag type-formal-less partialImu interfaces now too
- Don't worry type-formal-less partialImu if not directly marked