### PR TITLE
be-csharp: Mapped.toMap was too lenient when subject type was Mapped.

### DIFF
--- a/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/Core.cs
+++ b/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/Core.cs
@@ -120,12 +120,12 @@ namespace TemperLang.Core
 
         public static int UShr(this int a, int b)
         {
-            return (int) ((uint) a >> (b & 0x1f));
+            return (int)((uint)a >> (b & 0x1f));
         }
 
         public static long UShr(this long a, int b)
         {
-            return (long) ((ulong) a >> (b & 0x3f));
+            return (long)((ulong)a >> (b & 0x3f));
         }
 
         private const string DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz";
@@ -138,15 +138,17 @@ namespace TemperLang.Core
             if (n < 0)
             {
                 signed = true;
-                un = ((uint) ~n) + 1;
-            } else {
-                un = (uint) n;
+                un = ((uint)~n) + 1;
             }
-            uint uRadix = (uint) radix;
+            else
+            {
+                un = (uint)n;
+            }
+            uint uRadix = (uint)radix;
             // do...while means for 0 we get "0"
             do
             {
-                int digitValue = (int) (un % uRadix);
+                int digitValue = (int)(un % uRadix);
                 un = un / uRadix;
                 sb.Append(DIGITS[digitValue]);
             }
@@ -172,15 +174,17 @@ namespace TemperLang.Core
             if (n < 0)
             {
                 signed = true;
-                un = ((ulong) ~n) + 1;
-            } else {
-                un = (ulong) n;
+                un = ((ulong)~n) + 1;
             }
-            uint uRadix = (uint) radix;
+            else
+            {
+                un = (ulong)n;
+            }
+            uint uRadix = (uint)radix;
             // do...while means for 0 we get "0"
             do
             {
-                int digitValue = (int) (un % uRadix);
+                int digitValue = (int)(un % uRadix);
                 un = un / uRadix;
                 sb.Append(DIGITS[digitValue]);
             }

--- a/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/Listed.cs
+++ b/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/Listed.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -227,11 +228,10 @@ namespace TemperLang.Core
         }
 
         /// <summary>
-        /// Always ensures wrapping in ReadOnlyCollection. If collection is
-        /// already an IList, doesn't create a new one.
+        /// Always ensures converting to an immutable list. If collection is
+        /// already an ImmutableList, doesn't create a new one.
         /// </summary>
         public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> collection) =>
-            collection as ReadOnlyCollection<T>
-            ?? new ReadOnlyCollection<T>(collection as IList<T> ?? new List<T>(collection));
+            collection.ToImmutableList();
     }
 }

--- a/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
+++ b/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
@@ -13,12 +13,24 @@ namespace TemperLang.Core
         /// might also be held via a reference typed as Temper Map<...>.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue> dictionary
-        ) => dictionary.ToImmutableDictionary();
+        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
+            ? (ReadOnlyDictionaryWrapper<TKey, TValue>)dictionary
+            : (dictionary is ImmutableDictionary<TKey, TValue>)
+            ? (ImmutableDictionary<TKey, TValue>)dictionary
+            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
+                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
+            );
 
         /// ToMap needs to make a copy if input might be mutated.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary
-        ) => dictionary.ToImmutableDictionary();
+        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
+            ? (ReadOnlyDictionaryWrapper<TKey, TValue>)dictionary
+            : (dictionary is ImmutableDictionary<TKey, TValue>)
+            ? (ImmutableDictionary<TKey, TValue>)dictionary
+            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
+                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
+            );
 
         /// Duplicated for IDictionary below.
         #region Static Methods for IReadOnlyDictionary

--- a/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
+++ b/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace TemperLang.Core
@@ -12,20 +13,12 @@ namespace TemperLang.Core
         /// might also be held via a reference typed as Temper Map<...>.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue> dictionary
-        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
-            ? dictionary as ReadOnlyDictionaryWrapper<TKey, TValue>
-            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
-                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
-            );
+        ) => dictionary.ToImmutableDictionary();
 
         /// ToMap needs to make a copy if input might be mutated.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary
-        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
-            ? dictionary as ReadOnlyDictionaryWrapper<TKey, TValue>
-            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
-                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
-            );
+        ) => dictionary.ToImmutableDictionary();
 
         /// Duplicated for IDictionary below.
         #region Static Methods for IReadOnlyDictionary

--- a/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
+++ b/be-csharp/src/commonMain/resources/lang/temper/be/csharp/temper-core/OrderedDictionary.cs
@@ -7,17 +7,25 @@ namespace TemperLang.Core
 {
     public static class Mapped
     {
-        /// ToMap does not need to make a copy, if both are immutable
+        /// ToMap needs to make a copy if input might be aliased via a mutable API
+        /// because IReadOnlyDictionary is the same type as Temper Mapped<...>, so
+        /// might also be held via a reference typed as Temper Map<...>.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue> dictionary
-        ) => dictionary;
+        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
+            ? dictionary as ReadOnlyDictionaryWrapper<TKey, TValue>
+            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
+                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
+            );
 
-        /// ToMap needs to make a copy, the input is mutable
+        /// ToMap needs to make a copy if input might be mutated.
         public static IReadOnlyDictionary<TKey, TValue> ToMap<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary
-        ) => new ReadOnlyDictionaryWrapper<TKey, TValue>(
-            new OrderedDictionary<TKey, TValue>(dictionary.ToList())
-        );
+        ) => (dictionary is ReadOnlyDictionaryWrapper<TKey, TValue>)
+            ? dictionary as ReadOnlyDictionaryWrapper<TKey, TValue>
+            : new ReadOnlyDictionaryWrapper<TKey, TValue>(
+                new OrderedDictionary<TKey, TValue>(dictionary.ToList())
+            );
 
         /// Duplicated for IDictionary below.
         #region Static Methods for IReadOnlyDictionary

--- a/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
+++ b/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
@@ -456,6 +456,35 @@ class CSharpBackendTest {
     }
 
     @Test
+    fun mapBuilderToMap() {
+        assertGeneratedGlobalClass(
+            temper = """
+                |let builder: MapBuilder<String, String> = new MapBuilder<String, String>();
+                |export let map1 = builder.toMap();
+                |let mapped: Mapped<String, String> = builder;
+                |export let map2 = mapped.toMap();
+            """.trimMargin(),
+            usings = """
+                |using G = System.Collections.Generic;
+                |using C = TemperLang.Core;
+            """.trimMargin(),
+            csharp = """
+                |internal static G::IDictionary<string, string> builder__0;
+                |public static G::IReadOnlyDictionary<string, string> Map1;
+                |internal static G::IReadOnlyDictionary<string, string> mapped__0;
+                |public static G::IReadOnlyDictionary<string, string> Map2;
+                |static TestGlobal()
+                |{
+                |    builder__0 = new C::OrderedDictionary<string, string>();
+                |    Map1 = C::Mapped.ToMap(builder__0);
+                |    mapped__0 = C::Mapped.AsReadOnly(builder__0);
+                |    Map2 = C::Mapped.ToMap(mapped__0);
+                |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
     fun pureVirtualDefault() = assertGeneratedUserClass(
         temper = """
             |export interface A {

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
@@ -3,7 +3,6 @@ package lang.temper.be.java
 import lang.temper.be.Backend
 import lang.temper.be.BackendSetup
 import lang.temper.be.names.NameSelection
-import lang.temper.be.tmpl.LibraryRootContext
 import lang.temper.be.tmpl.SuperCallConfig
 import lang.temper.be.tmpl.SupportNetwork
 import lang.temper.be.tmpl.TmpL
@@ -13,7 +12,6 @@ import lang.temper.be.tmpl.injectSuperCallMethods
 import lang.temper.common.MimeType
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
-import lang.temper.library.LibraryConfiguration
 import lang.temper.library.LibraryConfigurations
 import lang.temper.log.FilePath
 import lang.temper.log.dirPath
@@ -167,12 +165,7 @@ class JavaBackend private constructor(
 
     override fun selectNames(): List<NameSelection> = names.allNames()
 
-    override fun libraryRootContext(libraryConfiguration: LibraryConfiguration) = LibraryRootContext(
-        inRoot = libraryConfiguration.libraryRoot,
-        outRoot = dirPath(libraryConfiguration.libraryName.text.safeIdentifier()),
-    )
-
-    /** Add per module resources. */
+    /** Add per-module resources. */
     override fun preWrite(outputFiles: List<OutputFileSpecification>): List<OutputFileSpecification> {
         val additions = mutableMapOf<FilePath, OutputFileSpecification>()
         val javaMime = factory.backendMeta.mimeTypeMap[FileType.Module]

--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
@@ -813,16 +813,14 @@ internal class JsTranslator(
             ImplicitTypeTag.Int -> op.isInt(pos, type, x)
             ImplicitTypeTag.String -> op.allHaveTypeof(pos, type, JsTypeOf.string, x)
             ImplicitTypeTag.Function -> op.allHaveTypeof(pos, type, JsTypeOf.function, x)
-            ImplicitTypeTag.ListBuilder, ImplicitTypeTag.List ->
+            ImplicitTypeTag.ListBuilder, ImplicitTypeTag.List, ImplicitTypeTag.Listed ->
                 // TODO(tjp, backend): Distinguish on frozen? Disable checks for List(Builder)?
                 op.isArray(pos, type, x)
             else -> {
                 val type = rt.ot.withoutBubbleOrNull
                 val nType = type as? TmpL.NominalType
                 val typeShape = nType?.typeName?.sourceDefinition as? TypeShape
-                if (typeShape == WellKnownTypes.listedTypeDefinition) {
-                    op.isArray(pos, type, x)
-                } else if (typeShape != null) {
+                if (typeShape != null) {
                     val typeName = translateIdStrict(TmpL.Id(rt.pos, typeShape.name))
                     op.instanceOf(pos, type, typeShape, typeName, x)
                 } else {

--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
@@ -727,11 +727,7 @@ internal class JsTranslator(
                     x: TmpL.Expression,
                 ) = Js.CallExpression(
                     pos,
-                    Js.MemberExpression(
-                        pos,
-                        Js.Identifier(pos, JsIdentifierName("Array"), null),
-                        Js.Identifier(pos, JsIdentifierName("isArray"), null),
-                    ),
+                    Js.Identifier(type.pos, requireExternalReference(requireIsArray), null),
                     listOf(translateExpression(x)),
                 )
             },
@@ -824,7 +820,9 @@ internal class JsTranslator(
                 val type = rt.ot.withoutBubbleOrNull
                 val nType = type as? TmpL.NominalType
                 val typeShape = nType?.typeName?.sourceDefinition as? TypeShape
-                if (typeShape != null) {
+                if (typeShape == WellKnownTypes.listedTypeDefinition) {
+                    op.isArray(pos, type, x)
+                } else if (typeShape != null) {
                     val typeName = translateIdStrict(TmpL.Id(rt.pos, typeShape.name))
                     op.instanceOf(pos, type, typeShape, typeName, x)
                 } else {
@@ -895,7 +893,7 @@ internal class JsTranslator(
             Js.ThisExpression(id.pos)
         } else {
             val jsName = JsIdentifierName(name.prefix())
-            return Js.Identifier(
+            Js.Identifier(
                 pos = id.pos,
                 name = jsName,
                 sourceIdentifier = name as? ResolvedParsedName,
@@ -948,7 +946,7 @@ internal class JsTranslator(
                 specifiers = emptyList(),
                 source = null,
             )
-            return topLevelsWithExport.toList()
+            topLevelsWithExport.toList()
         } else {
             topLevels
         }
@@ -1074,7 +1072,7 @@ internal class JsTranslator(
                     // Make sure to capture it via that name.
                     TODO()
                     // Can this actually happen?  What does the `this`
-                    // parameter mean in that case
+                    // parameter mean in that case?
                 }
                 buildList {
                     add(
@@ -2208,6 +2206,11 @@ internal val bubbleException = JsIdentifierName("Error")
 internal val requireInstanceOf = JsUnInlinedExternalFunctionReference(
     DashedIdentifier.temperCoreLibraryIdentifier,
     JsIdentifierName("requireInstanceOf"),
+)
+
+internal val requireIsArray = JsUnInlinedExternalFunctionReference(
+    DashedIdentifier.temperCoreLibraryIdentifier,
+    JsIdentifierName("requireIsArray"),
 )
 
 internal val requireSame = JsUnInlinedExternalFunctionReference(

--- a/be-js/src/commonMain/resources/lang/temper/be/js/temper-core/check-type.js
+++ b/be-js/src/commonMain/resources/lang/temper/be/js/temper-core/check-type.js
@@ -21,6 +21,18 @@ export const requireInstanceOf = (x, typeRequirement) => {
 
 /**
  * @template T
+ * @param {any} x
+ * @returns {Array<T> | ReadonlyArray<T>}
+ */
+export const requireIsArray = (x) => {
+  if (!Array.isArray(x)) {
+    bubble();
+  }
+  return x;
+};
+
+/**
+ * @template T
  * @param {T?} x
  * @returns {T}
  */

--- a/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
+++ b/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
@@ -332,7 +332,7 @@ class JsBackendTest {
         """.trimMargin()
 
         // The transfer of console from internal is odd but not broken.
-        // It's still unavailable from the public js module.
+        // It's still unavailable from the public JS module.
         val want = """
             |{
             |  "js": {
@@ -1971,6 +1971,46 @@ class JsBackendTest {
             |      "foo.js.map": "__DO_NOT_CARE__",
             |      $OUTPUT_BOILERPLATE
             |    },
+            |  }
+            |}
+        """.trimMargin(),
+    )
+
+    @Test
+    fun castListBuilderToListed() = assertGeneratedCode(
+        inputs = inputFileMapFromJson(
+            """
+                |{
+                |  casty: {
+                |    casty.temper: ```
+                |      let lb = new ListBuilder<String>();
+                |      export let listed = lb as Listed<String>;
+                |      ```
+                |  }
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |  js: {
+            |    my-test-library: {
+            |      casty.js: {
+            |        content: ```
+            |          import {
+            |            requireIsArray as requireIsArray_0
+            |          } from "@temperlang/core";
+            |          /** @type {Array<string>} */
+            |          const lb_0 = [];
+            |          /** @type {Array<string>} */
+            |          export let listed;
+            |          listed = requireIsArray_0(lb_0);
+            |
+            |          ```,
+            |      },
+            |      casty.js.map: "__DO_NOT_CARE__",
+            |      index.js:     "__DO_NOT_CARE__",
+            |      package.json: "__DO_NOT_CARE__",
+            |    }
             |  }
             |}
         """.trimMargin(),

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
@@ -222,7 +222,7 @@ private class ModuleParts(
                         MethodKind.Getter -> "get"
                         MethodKind.Setter -> "set"
                         else -> "methods"
-                    }.let { it -> subject.dot(it).dotSafe(dotName).call(args.value) }
+                    }.let { subject.dot(it).dotSafe(dotName).call(args.value) }
                     // Others are standard method calls.
                     else -> Lua.MethodCallExpr(
                         expr.pos,
@@ -284,8 +284,10 @@ private class ModuleParts(
             ImplicitTypeTag.Function -> castFunc("cast_to_function")
             ImplicitTypeTag.List -> castFunc("cast_to_list")
             ImplicitTypeTag.ListBuilder -> castFunc("cast_to_listbuilder")
+            ImplicitTypeTag.Listed -> castFunc("cast_to_listed")
             ImplicitTypeTag.Map -> castFunc("cast_to_map")
             ImplicitTypeTag.MapBuilder -> castFunc("cast_to_mapbuilder")
+            ImplicitTypeTag.Mapped -> castFunc("cast_to_mapped")
             ImplicitTypeTag.Null -> castFunc("cast_to_null")
             ImplicitTypeTag.Other -> {
                 val typeName = (expr.checkedType.ot.withoutBubbleOrNull as TmpL.NominalType)
@@ -339,29 +341,30 @@ private class ModuleParts(
                 Lua.Str(expr.checkedType.pos, typeStr),
             )
 
-        fun hasTag(tag: Lua.Name): Lua.Expr =
+        fun hasTag(tags: List<Lua.Name>): Lua.Expr {
             // temper.instance_of(expr, tag)
-            Lua.FunctionCallExpr(
+            return Lua.FunctionCallExpr(
                 expr.pos,
                 Lua.DotIndexExpr(
-                    expr.pos,
-                    Lua.Name(expr.pos, name("temper")),
-                    Lua.Name(expr.pos, name("instance_of")),
+                    expr.pos.leftEdge,
+                    Lua.Name(expr.pos.leftEdge, name("temper")),
+                    Lua.Name(expr.pos.leftEdge, name("instance_of")),
                 ),
                 Lua.Args(
                     expr.pos,
                     Lua.Exprs(
                         expr.pos,
-                        listOf(
-                            translateExpr(expr.expr),
-                            tag,
-                        ),
+                        listOf(translateExpr(expr.expr)) + tags,
                     ),
                 ),
             )
+        }
 
         fun hasTag(tagText: String) =
-            hasTag(Lua.Name(expr.checkedType.pos, name(tagText)))
+            hasTag(listOf(Lua.Name(expr.checkedType.pos, name(tagText))))
+
+        fun hasTag(tagTextA: String, tagTextB: String) =
+            hasTag(listOf(tagTextA, tagTextB).map { Lua.Name(expr.checkedType.pos, name(it)) })
 
         return when (expr.checkedType.implicitTypeTag) {
             ImplicitTypeTag.Boolean -> typeEq("boolean")
@@ -371,19 +374,16 @@ private class ModuleParts(
             ImplicitTypeTag.Function -> typeEq("function")
             ImplicitTypeTag.List -> hasTag("List")
             ImplicitTypeTag.ListBuilder -> hasTag("ListBuilder")
+            ImplicitTypeTag.Listed -> hasTag("List", "ListBuilder")
             ImplicitTypeTag.Map -> hasTag("Map")
             ImplicitTypeTag.MapBuilder -> hasTag("MapBuilder")
+            ImplicitTypeTag.Mapped -> hasTag("Map", "MapBuilder")
             ImplicitTypeTag.Null -> TODO("should call isNull")
             ImplicitTypeTag.Void -> TODO("cast to Void")
             ImplicitTypeTag.Other -> {
                 val typeName = (expr.checkedType.ot.withoutBubbleOrNull as TmpL.NominalType)
                     .typeName.sourceDefinition.name
-                hasTag(
-                    Lua.Name(
-                        expr.pos,
-                        luaNames.name(typeName),
-                    ),
-                )
+                hasTag(listOf(Lua.Name(expr.checkedType.pos, luaNames.name(typeName))))
             }
         }
     }

--- a/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
+++ b/be-lua/src/commonMain/resources/lang/temper/be/lua/temper-core/init.lua
@@ -1979,6 +1979,13 @@ function temper.cast_to_listbuilder(thing)
     return thing
 end
 
+function temper.cast_to_listed(thing)
+    if type(thing) ~= 'table' or (thing[temper.type_tag] ~= 'List' and thing[temper.type_tag] ~= 'ListBuilder') then
+        return temper.bubble("cast to Listed")
+    end
+    return thing
+end
+
 function temper.cast_to_map(thing)
     if type(thing) ~= 'table' or thing[temper.type_tag] ~= 'Map' then
         return temper.bubble("cast to Map")
@@ -1989,6 +1996,13 @@ end
 function temper.cast_to_mapbuilder(thing)
     if type(thing) ~= 'table' or thing[temper.type_tag] ~= 'MapBuilder' then
         return temper.bubble("cast to MapBuilder")
+    end
+    return thing
+end
+
+function temper.cast_to_map(thing)
+    if type(thing) ~= 'table' or (thing[temper.type_tag] ~= 'Map' and thing[temper.type_tag] ~= 'MapBuilder') then
+        return temper.bubble("cast to Mapped")
     end
     return thing
 end
@@ -2008,8 +2022,19 @@ function temper.cast_to(thing, type)
     end
 end
 
-function temper.instance_of(thing, tag)
-    return type(thing) == "table" and thing[temper.type_tag].super[tag.typename]
+function temper.instance_of(thing, ...)
+    if type(thing) ~= "table" then
+        return false
+    end
+    local n = select('#', ...)
+    local type_tag = temper.type_tag
+    for i=1,n do
+        local tag = select(i, ...)
+        if thing[type_tag].super[tag.typename] then
+            return true
+        end
+    end
+    return false
 end
 
 function temper.test_bail()

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
@@ -11,7 +11,6 @@ import lang.temper.be.names.NameSelection
 import lang.temper.be.py.PyDottedIdentifier.Companion.dotted
 import lang.temper.be.py.helper.MypySpecifics
 import lang.temper.be.py.helper.PythonSpecifics
-import lang.temper.be.tmpl.LibraryRootContext
 import lang.temper.be.tmpl.SupportNetwork
 import lang.temper.be.tmpl.TmpL
 import lang.temper.be.tmpl.TmpLTranslator
@@ -21,7 +20,6 @@ import lang.temper.common.console
 import lang.temper.common.jsonEscaper
 import lang.temper.common.partitionNotNull
 import lang.temper.common.toStringViaBuilder
-import lang.temper.frontend.Module
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
 import lang.temper.fs.loadResource
@@ -358,11 +356,6 @@ class PyBackend private constructor(
     }
 
     override fun selectNames(): List<NameSelection> = pyNames!!.selectedNames()
-
-    override fun libraryRootContext(libraryConfiguration: LibraryConfiguration) = LibraryRootContext(
-        inRoot = libraryConfiguration.libraryRoot,
-        outRoot = safeForImportFilePath(dirPath(libraryConfiguration.libraryName.text)),
-    )
 
     private fun pyPathForModuleLocation(
         moduleName: ModuleName,

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
@@ -152,10 +152,11 @@ class RustBackend(setup: BackendSetup<RustBackend>) : Backend<RustBackend>(Facto
                     append("regex = { version = \"=1.12.2\", optional = true }\n")
                     append("time = { version = \"=0.3.41\", optional = true }\n")
                     append("ureq = { version = \"=3.1.2\", optional = true }\n")
+                    append("zeroize = { version = \"=1.8.2\", optional = true }\n")
                     // Below aren't dependencies section anymore, but eh.
                     append("\n")
                     append("[features]\n")
-                    append("net = [\"ureq\"]\n")
+                    append("net = [\"ureq\", \"zeroize\"]\n")
                     // Implied: append("regex = [\"regex\"]\n")
                     append("temporal = [\"time\"]\n")
                 }

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -1036,27 +1036,29 @@ class RustTranslator(
         pos: Position,
         found: Description,
         wanted: Description,
-    ): Rust.Path = when {
-        found.definition() == WellKnownTypes.noStringIndexTypeDefinition &&
-            wanted.definition() == WellKnownTypes.stringIndexOptionTypeDefinition
-        -> "temper_core".toKeyId(pos).extendWith(listOf("string", "cast_none_as_index_option"))
-
-        found.definition() == WellKnownTypes.stringIndexTypeDefinition &&
-            wanted.definition() == WellKnownTypes.stringIndexOptionTypeDefinition -> makePath(pos, "Some")
-
-        found.definition() == WellKnownTypes.stringIndexOptionTypeDefinition &&
-            wanted.definition() == WellKnownTypes.stringIndexTypeDefinition
-        -> "temper_core".toKeyId(pos).extendWith(listOf("string", "cast_as_index"))
-
-        found.definition() == WellKnownTypes.stringIndexOptionTypeDefinition &&
-            wanted.definition() == WellKnownTypes.noStringIndexTypeDefinition
-        -> "temper_core".toKeyId(pos).extendWith(listOf("string", "cast_as_no_index"))
-
-        else -> {
-            val typeSegment = Rust.GenericArgs(pos, listOf(translateType(wanted.type!!, pos)))
-            // TODO Some way to make fewer intermediate lists?
-            "temper_core".toKeyId(pos).extendWith("cast").extendWith(listOf(typeSegment))
+    ): Rust.Path = when (found.definition()) {
+        WellKnownTypes.listTypeDefinition, WellKnownTypes.listBuilderTypeDefinition -> when (wanted.definition()) {
+            WellKnownTypes.listedTypeDefinition -> TO_LISTED_TO_LISTED_NAME.toId(pos)
+            else -> null
         }
+        WellKnownTypes.noStringIndexTypeDefinition -> when (wanted.definition()) {
+            WellKnownTypes.stringIndexOptionTypeDefinition -> "cast_none_as_index_option"
+            else -> null
+        }?.let { "temper_core".toKeyId(pos).extendWith(listOf("string", it)) }
+        WellKnownTypes.stringIndexTypeDefinition -> when (wanted.definition()) {
+            WellKnownTypes.stringIndexOptionTypeDefinition -> makePath(pos, "Some")
+            else -> null
+        }
+        WellKnownTypes.stringIndexOptionTypeDefinition -> when (wanted.definition()) {
+            WellKnownTypes.stringIndexTypeDefinition -> "cast_as_index"
+            WellKnownTypes.noStringIndexTypeDefinition -> "cast_as_no_index"
+            else -> null
+        }?.let { "temper_core".toKeyId(pos).extendWith(listOf("string", it)) }
+        else -> null
+    } ?: run {
+        val typeSegment = Rust.GenericArgs(pos, listOf(translateType(wanted.type!!, pos)))
+        // TODO Some way to make fewer intermediate lists?
+        "temper_core".toKeyId(pos).extendWith("cast").extendWith(listOf(typeSegment))
     }
 
     private fun buildDerive(pos: Position, deriveArgs: List<String>) = Rust.AttrOuter(
@@ -1825,6 +1827,12 @@ class RustTranslator(
             }
         }.let { result ->
             when {
+                // Upcasting to listed doesn't need checked at all for any valid casts.
+                // Any invalid casts are reported as errors by frontend validation.
+                // But we still need to wrapOk because outer layers with less context still
+                // see the claimed tmpl type as being bubbly.
+                wanted.definition() == WellKnownTypes.listedTypeDefinition -> result.wrapOk()
+                // For others, trust standard type expectations.
                 cast.type.described().bubbly -> result.wrapOkOrElse(pos)
                 else -> result.methodCall("unwrap") // such as for assertAs
             }

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -5,7 +5,6 @@ import lang.temper.be.cli.CliEnv
 import lang.temper.be.cli.RunnerSpecifics
 import lang.temper.be.names.NameSelection
 import lang.temper.be.names.NameSelectionFile
-import lang.temper.be.tmpl.LibraryRootContext
 import lang.temper.be.tmpl.SignatureAdjustments
 import lang.temper.be.tmpl.SupportNetwork
 import lang.temper.be.tmpl.TmpL
@@ -44,7 +43,6 @@ import lang.temper.log.FileRelatedCodeLocation
 import lang.temper.log.LogSink
 import lang.temper.log.MessageTemplate
 import lang.temper.log.bannedPathSegmentNames
-import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
 import lang.temper.log.plus
@@ -647,13 +645,6 @@ abstract class Backend<SELF : Backend<SELF>>(
             )
         }
     }
-
-    /** Locates the temper source files for a library */
-    open fun libraryRootContext(libraryConfiguration: LibraryConfiguration) =
-        LibraryRootContext(
-            inRoot = libraryConfiguration.libraryRoot,
-            outRoot = dirPath(libraryConfiguration.libraryName.text),
-        )
 
     private val allocatedFiles = mutableSetOf<FilePath>()
     protected fun allocateTextFile(

--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLHelpers.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLHelpers.kt
@@ -5,7 +5,6 @@ import lang.temper.be.Backend
 import lang.temper.common.RFailure
 import lang.temper.common.RSuccess
 import lang.temper.format.TokenSink
-import lang.temper.frontend.Module
 import lang.temper.frontend.ModuleNamingContext
 import lang.temper.lexer.Genre
 import lang.temper.lexer.withTemperAwareExtension
@@ -431,7 +430,7 @@ fun TmpL.MemberOrGarbage.asReceiverMember(): ReceiverMember? = when (this) {
  * Member dotNames (methods, getters, setters) across [modules] whose receiver (`this`)
  * may be mutated when the member runs — directly (a property write or setter call on
  * `this`) or transitively (calling another such member on `this`). Setters always
- * qualify. The result is keyed by dotName so it is identical for every declaration in an
+ * qualify. The result is keyed by dotName, so it is identical for every declaration in an
  * override slot, which is what lets a backend emit a `const`/readonly qualifier
  * consistently (C++ requires matching const-ness across a virtual override slot).
  *
@@ -634,26 +633,6 @@ object GetStaticSupport : InlineTmpLSupportCode {
 operator fun TmpL.Declaration.get(key: Symbol) =
     metadata.find { it.key.symbol == key }?.value
 
-/**
- * Modules usually carry the library name, so we can interpret them for the output root.
- * However, in some cases, such as currently for docgen and repl, we don't yet provide
- * library names, so we need to relativize based on the input path.
- */
-class LibraryRootContext(
-    /** The input path to the library root containing Temper source. */
-    val inRoot: FilePath,
-    /** The output path to the library root, based on the library name, that will contain backend code. */
-    val outRoot: FilePath,
-) {
-    fun rootFor(module: TmpL.Module) = rootFor(module.codeLocation.origin)
-    fun rootFor(module: Module) = rootFor(module.namingContext)
-    fun rootFor(origin: NamingContext) = when (origin) {
-        is ModuleNamingContext -> outRoot
-        // This currently can happen at least in docgen and repl.
-        else -> inRoot
-    }
-}
-
 val TmpL.Type.withoutNullOrBubble: TmpL.Type get() = this.withoutAtom {
     it is TmpL.BubbleType ||
         (it is TmpL.NominalType && it.typeName.sourceDefinition == WellKnownTypes.nullTypeDefinition)
@@ -754,8 +733,10 @@ enum class ImplicitTypeTag {
     String,
     List,
     ListBuilder,
+    Listed,
     Map,
     MapBuilder,
+    Mapped,
     Null,
     Void,
     Other,
@@ -778,8 +759,10 @@ val TmpL.NominalType.implicitTypeTag: ImplicitTypeTag get() = when (this.typeNam
     WellKnownTypes.functionTypeDefinition -> ImplicitTypeTag.Function
     WellKnownTypes.intTypeDefinition -> ImplicitTypeTag.Int
     WellKnownTypes.listTypeDefinition -> ImplicitTypeTag.List
+    WellKnownTypes.listedTypeDefinition -> ImplicitTypeTag.Listed
     WellKnownTypes.listBuilderTypeDefinition -> ImplicitTypeTag.ListBuilder
     WellKnownTypes.mapTypeDefinition -> ImplicitTypeTag.Map
+    WellKnownTypes.mappedTypeDefinition -> ImplicitTypeTag.Mapped
     WellKnownTypes.mapBuilderTypeDefinition -> ImplicitTypeTag.MapBuilder
     WellKnownTypes.nullTypeDefinition -> ImplicitTypeTag.Null
     WellKnownTypes.stringTypeDefinition -> ImplicitTypeTag.String
@@ -1094,9 +1077,9 @@ internal fun <BE : Backend<BE>> TmpL.TypeDeclaration.injectSuperCallMethods(
  *
  * TODO Move out of tmpl?
  */
-fun TypeShape.findImmediateSuperReaching(inherited: MethodShape): NominalType? = run {
+fun TypeShape.findImmediateSuperReaching(inherited: MethodShape): NominalType? {
     val target = inherited.enclosingType
-    fun dig(shape: TypeShape): NominalType? = run {
+    fun dig(shape: TypeShape): NominalType? {
         superTypes@ for (sup in shape.superTypes) {
             val supShape = sup.definition as? TypeShape ?: continue@superTypes
             if (supShape == target) {
@@ -1115,14 +1098,14 @@ fun TypeShape.findImmediateSuperReaching(inherited: MethodShape): NominalType? =
             }
         }
         // No path found this way.
-        null
+        return null
     }
-    dig(this)
+    return dig(this)
 }
 
-fun TmpL.TypeDeclaration.hasSplitSupers(inherited: TmpL.SuperTypeMethod): Boolean = run {
+fun TmpL.TypeDeclaration.hasSplitSupers(inherited: TmpL.SuperTypeMethod): Boolean {
     val kind = (inherited.memberOverride.superTypeMember as? MethodShape)?.methodKind ?: return false
-    typeShape.hasSplitSupers(kind, inherited.name.dotNameText)
+    return typeShape.hasSplitSupers(kind, inherited.name.dotNameText)
 }
 
 /**

--- a/functional-test-suite/src/commonMain/resources/types/list/operations/operations.temper.md
+++ b/functional-test-suite/src/commonMain/resources/types/list/operations/operations.temper.md
@@ -411,3 +411,30 @@ C\# had a problem with these, trying to make overloads in local variables.
 ```log
 Called with listed.
 ```
+
+## List / ListBuilder independence
+
+This mirrors tests related to the Map / MapBuilder relationship
+to show we can build a list, and continue to mutate the builder
+without affecting previously built lists.
+
+    do {
+      let aListBuilder = new ListBuilder<String>();
+      aListBuilder.add("first");
+
+      let builtFirst = aListBuilder.toList();
+
+      aListBuilder.add("second");
+
+      let builtSecond = (aListBuilder as Listed<String>).toList();
+
+      aListBuilder.add("third");
+
+      console.log("builtFirst has ${builtFirst.join(", ") { s => s }}");
+      console.log("builtSecond has ${builtSecond.join(", ") { s => s }}");
+    }
+
+```log
+builtFirst has first
+builtSecond has first, second
+```

--- a/functional-test-suite/src/commonMain/resources/types/map/map.temper.md
+++ b/functional-test-suite/src/commonMain/resources/types/map/map.temper.md
@@ -220,14 +220,26 @@ other key = other value
 added key = added value
 ```
 
+Casting the builder to a mapped doesn't lead to false assumptions about
+the API not allowing mutation preventing mutation by code that has an alias
+via a mutable API.
+
+    let builderAsMapped: Mapped<String, String> = builder;
+    let newMapFromMapped = builderAsMapped.toMap();
+
 The resulting map is immutable, so changes to the builder no longer impact it
 
     builder.remove("other key");
     builder["key"] = "double replaced value";
     printMap("builder to map (same as above)", newMap);
+    printMap("builder to map via mapped (same as above)", newMapFromMapped);
 
 ```log
 --- builder to map (same as above) ---
+key = replaced value
+other key = other value
+added key = added value
+--- builder to map via mapped (same as above) ---
 key = replaced value
 other key = other value
 added key = added value


### PR DESCRIPTION
The **type Map** functional test checks that `MapBuilder.toMap()` copies defensively.

This adds code to check that `Mapped.toMap` also does.

be-csharp's implementation of those allowed for two subject signatures and optimistically assumed that something typed as IReadOnlyMap was not mutable, but it can be an alias to a reference to a MapBuilder.