### PR TITLE
Rust chain builder

### DIFF
--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
@@ -152,10 +152,11 @@ class RustBackend(setup: BackendSetup<RustBackend>) : Backend<RustBackend>(Facto
                     append("regex = { version = \"=1.12.2\", optional = true }\n")
                     append("time = { version = \"=0.3.41\", optional = true }\n")
                     append("ureq = { version = \"=3.1.2\", optional = true }\n")
+                    append("zeroize = { version = \"=1.8.2\", optional = true }\n")
                     // Below aren't dependencies section anymore, but eh.
                     append("\n")
                     append("[features]\n")
-                    append("net = [\"ureq\"]\n")
+                    append("net = [\"ureq\", \"zeroize\"]\n")
                     // Implied: append("regex = [\"regex\"]\n")
                     append("temporal = [\"time\"]\n")
                 }

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustExt.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustExt.kt
@@ -377,13 +377,28 @@ internal fun Rust.FunctionParamOption.toId(): Rust.Id {
     }
 }
 
-internal fun Rust.GenericParam.toArg(): Rust.Id {
+internal fun Iterable<Rust.GenericParam>.except(unwanteds: Iterable<Rust.GenericParam>): List<Rust.GenericParam> {
+    val unwantedIdTexts = unwanteds.mapTo(mutableSetOf()) { it.lastIdText() }
+    return buildList {
+        for (generic in this@except) {
+            if (generic.lastIdText() !in unwantedIdTexts) {
+                add(generic.deepCopy())
+            }
+        }
+    }
+}
+
+internal fun Rust.GenericParam.lastId(): Rust.Id {
     return when (this) {
         is Rust.Id -> this
         is Rust.TypeParam -> id
         is Rust.PathSegments -> segments.last() as Rust.Id
-    }.deepCopy()
+    }
 }
+
+internal fun Rust.GenericParam.lastIdText(): String = lastId().outName.outputNameText
+
+internal fun Rust.GenericParam.toArg(): Rust.Id = lastId().deepCopy()
 
 internal fun Rust.Path.makeTypeRef(generics: List<Rust.GenericParam>): Rust.Type = when {
     generics.isEmpty() -> this

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -96,9 +96,10 @@ class RustTranslator(
         DescriptorsForDeclarations.Key(RustBackend.Factory),
     )?.nameToDescriptor ?: mapOf()
     private var closureCount = 0
+    private val builderItems = mutableListOf<Rust.Item>()
     private val decls = mutableMapOf<ResolvedName, DeclInfo>()
-    private var insideMutableType = false
     private val failVars = mutableSetOf<ResolvedName>()
+    private var insideMutableType = false
     private val functionContextStack = mutableListOf<FunctionContext>()
     private val logSink = LogSink.devNull // TODO what?
     private val loopLabels = mutableListOf<Rust.Id?>()
@@ -179,6 +180,15 @@ class RustTranslator(
                     // Init and declare our own things.
                     add(init)
                     addAll(moduleItems)
+                    // Builders.
+                    if (builderItems.isNotEmpty()) {
+                        builderItems.add(Rust.Use(pos, "super::*".toId(pos)).toItem())
+                        Rust.Module(
+                            pos,
+                            id = "builders".toId(pos), // TODO Uniqueness?
+                            block = Rust.Block(pos, statements = builderItems),
+                        ).toItem().also { add(it) }
+                    }
                     // Tests.
                     if (testItems.isNotEmpty()) {
                         testItems.add(Rust.Use(pos, "super::*".toId(pos)).toItem())
@@ -358,6 +368,37 @@ class RustTranslator(
         }.let { (requireds, optionals) ->
             requireds.map { it.second } to optionals.map { it.second }
         }
+        fun paramsToStructAddedChain(): List<Rust.GenericParam> {
+            val id = builderId.deepCopy() // TODO Stop the deepCopy later.
+            val params = rustParams
+            val attrs = listOf(buildDerive(pos, listOf("Clone", "Default")))
+            val usedTypes = params.findAllSimpleTypeNames()
+            val filteredGenerics = generics.filter { genericReused ->
+                val generic = genericReused.deepCopy() // TODO Stop the deepCopy later.
+                val genericId = when (generic) {
+                    is Rust.Id -> generic
+                    is Rust.TypeParam -> generic.id
+                    else -> error(generic)
+                }.outName.outputNameText
+                genericId in usedTypes
+            }.deepCopy()
+            Rust.Struct(
+                pos = pos,
+                id = id,
+                generics = filteredGenerics,
+                fields = paramPairs.map { (tmpl, paramReused) ->
+                    val param = paramReused.deepCopy() // TODO Stop the deepCopy later.
+                    param as Rust.FunctionParam
+                    val type = when {
+                        tmpl.optional -> param.type
+                        else -> param.type?.deepCopy()?.option()
+                    }
+                    Rust.StructField(param.pos, pub = pub, id = param.pattern as Rust.Id, type = type)
+                },
+            ).also { builderItems.add(it.toItem(attrs = attrs, pub = pub)) }
+            return filteredGenerics
+        }
+        paramsToStructAddedChain()
         fun paramsToStructAdded(
             id: Rust.Id,
             params: List<Rust.FunctionParamOption>,

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -414,8 +414,9 @@ class RustTranslator(
             else -> {
                 // Manage optionals independently so they can default more easily.
                 val attrs = listOf(buildDerive(pos, listOf("Clone")))
+                val selfishParam = Rust.FunctionParam(pos, selfish.deepCopy(), builderId.makeTypeRef(filteredGenerics))
                 val selfishPlusOptionals = buildList {
-                    add(Rust.FunctionParam(pos, selfish.deepCopy(), builderId.makeTypeRef(filteredGenerics)))
+                    add(selfishParam)
                     addAll(optionals)
                 }
                 val optionalGenerics = paramsToStructAdded(optionsId, selfishPlusOptionals, attrs = attrs)
@@ -425,6 +426,26 @@ class RustTranslator(
                     trait = null,
                     type = optionsId.makeTypeRef(optionalGenerics),
                     items = buildList {
+                        Rust.Function(
+                            pos,
+                            id = "new".toId(pos),
+                            params = listOf(selfishParam.deepCopy()),
+                            returnType = "Self".toKeyId(pos),
+                            block = Rust.Block(
+                                pos,
+                                result = Rust.StructExpr(
+                                    pos,
+                                    id = "Self".toKeyId(pos),
+                                    members = buildList {
+                                        add(Rust.StructExprField(pos, selfish.deepCopy(), null))
+                                        for (param in optionals) {
+                                            param is Rust.FunctionParam
+                                            add(Rust.StructExprField(pos, param.toId(), expr = "None".toId(pos)))
+                                        }
+                                    },
+                                ),
+                            ),
+                        ).also { add(it.toItem(pub = pub.deepCopy())) }
                         for (param in optionals) {
                             param as Rust.FunctionParam
                             // Undo optional for setter method params.

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -334,7 +334,7 @@ class RustTranslator(
         returnType: Type2,
     ) {
         // TODO Share this exclusion logic with Java & Js.
-        // If only `this` plus up to 1 more, don't bother with builder. TODO Instead checked named/optional?
+        // If only `this` plus up to 1 more, don't bother with builder.
         fn.parameters.parameters.count { it.name != fn.parameters.thisName } <= 1 && return
         // And for now, skip those with rest parameters. TODO Extract to list value?
         fn.parameters.restParameter != null && return
@@ -353,7 +353,7 @@ class RustTranslator(
         val builderId = "${targetId.outName.outputNameText}Builder".toId(targetId.pos)
         val optionsId = "${targetId.outName.outputNameText}Options".toId(targetId.pos)
         // Figure out if we have requireds and/or optionals.
-        // We need to separate these in Rust because requireds often can't Default.
+        // We need to separate these in Rust because requireds often can't default.
         // We could get fancy about which requireds can, but that also becomes cognitive effort for users.
         val rustParams = translateParameters(
             fn.parameters,
@@ -369,107 +369,12 @@ class RustTranslator(
             requireds.map { it.second } to optionals.map { it.second }
         }
         val self = "self".toKeyId(pos)
-        fun paramsToStructAddedChain(): List<Rust.GenericParam> {
-            val id = builderId.deepCopy() // TODO Stop the deepCopy later.
-            val params = rustParams
-            val attrs = listOf(buildDerive(pos, listOf("Clone", "Default")))
-            val usedTypes = params.findAllSimpleTypeNames()
-            val filteredGenerics = generics.filter { genericReused ->
-                val generic = genericReused.deepCopy() // TODO Stop the deepCopy later.
-                val genericId = when (generic) {
-                    is Rust.Id -> generic
-                    is Rust.TypeParam -> generic.id
-                    else -> error(generic)
-                }.outName.outputNameText
-                genericId in usedTypes
-            }.deepCopy()
-            Rust.Struct(
-                pos = pos,
-                id = id,
-                generics = filteredGenerics,
-                fields = paramPairs.map { (tmpl, paramReused) ->
-                    val param = paramReused.deepCopy() // TODO Stop the deepCopy later.
-                    param as Rust.FunctionParam
-                    val type = when {
-                        tmpl.optional -> param.type
-                        // Add optional for storage.
-                        else -> param.type?.deepCopy()?.option()
-                    }
-                    Rust.StructField(param.pos, pub = pub, id = param.pattern as Rust.Id, type = type)
-                },
-            ).also { builderItems.add(it.toItem(attrs = attrs, pub = pub)) }
-            Rust.Impl(
-                pos = pos,
-                generics = filteredGenerics.deepCopy(),
-                trait = null,
-                type = builderId.makeTypeRef(filteredGenerics),
-                items = buildList methods@{
-                    for ((tmpl, param) in paramPairs) {
-                        param as Rust.FunctionParam
-                        val type = when {
-                            // Undo optional for setter method params.
-                            tmpl.optional -> (param.type as? Rust.GenericType)?.args?.first() as Rust.Type?
-                            else -> param.type
-                        }?.deepCopy()
-                        val paramId = param.pattern as Rust.Id
-                        Rust.Function(
-                            pos = param.pos,
-                            id = paramId.deepCopy(),
-                            params = listOf(
-                                Rust.FunctionParam(
-                                    pos = param.pos,
-                                    pattern = Rust.IdPattern(pos, Rust.IdPatternMut(pos), self.deepCopy()),
-                                    type = null,
-                                ),
-                                Rust.FunctionParam(
-                                    pos = param.pos,
-                                    pattern = paramId.deepCopy(),
-                                    type = type,
-                                ),
-                            ),
-                            returnType = "Self".toKeyId(param.pos),
-                            block = Rust.Block(
-                                pos,
-                                statements = Rust.ExprStatement(
-                                    param.pos,
-                                    Rust.Operation(
-                                        param.pos,
-                                        self.deepCopy().member(paramId.deepCopy(), notMethod = true),
-                                        Rust.Operator(pos, RustOperator.Assign),
-                                        paramId.deepCopy().wrapSome(),
-                                    ),
-                                ).let { listOf(it) },
-                                result = self.deepCopy(),
-                            ),
-                        ).also { this@methods.add(it.toItem()) }
-                    }
-//                    Rust.Function(
-//                        pos,
-//                        id = "build".toId(pos),
-//                        params = listOf(self),
-//                        returnType = rustReturnType,
-//                        block = Rust.Block(
-//                            pos,
-//                            result = when {
-//                                // Just call the constructor if we only have requireds.
-//                                optionals.isEmpty() -> callNew(requireds)
-//                                // Delegate to the with-optionals builder.
-//                                else -> self.deepCopy().methodCall(
-//                                    key = "build_with",
-//                                    args = listOf(makePath(pos, "std", "default", "Default", "default").call()),
-//                                )
-//                            },
-//                        ),
-//                    ).also { add(it.toItem(pub = pub)) }
-                }
-            ).also { builderItems.add(it.toItem()) }
-            return filteredGenerics
-        }
-        paramsToStructAddedChain()
+        val selfish = "selfish".toKeyId(pos)
         fun paramsToStructAdded(
             id: Rust.Id,
             params: List<Rust.FunctionParamOption>,
             attrs: List<Rust.AttrOuter> = listOf(),
+            fieldPub: Rust.VisibilityPub? = null,
         ): List<Rust.GenericParam> {
             // Work with Rust nodes rather than TmpL nodes because we already have generics handy in Rust form.
             // Any simple type name matching a formal has to be a reference to that formal.
@@ -488,9 +393,9 @@ class RustTranslator(
                 generics = filteredGenerics,
                 fields = params.map { param ->
                     param as Rust.FunctionParam
-                    Rust.StructField(param.pos, pub = pub, id = param.pattern as Rust.Id, type = param.type)
+                    Rust.StructField(param.pos, pub = fieldPub, id = param.pattern as Rust.Id, type = param.type)
                 },
-            ).also { moduleItems.add(it.toItem(attrs = attrs, pub = pub)) }
+            ).also { builderItems.add(it.toItem(attrs = attrs, pub = pub)) }
             return filteredGenerics
         }
         fun callNew(params: List<Rust.FunctionParamOption>) = Rust.Call(
@@ -498,77 +403,71 @@ class RustTranslator(
             callee = targetId.deepCopy().extendWith("new"),
             args = params.map { self.deepCopy().member(it.toId(), notMethod = true) },
         )
+        // Requireds struct first to get its generics.
+        // Adding new requireds is a breaking change anyway, so presume this is also fixed in Rust.
+        val attrs = listOf(buildDerive(pos, listOf("Clone")))
+        val filteredGenerics = paramsToStructAdded(builderId, requireds, attrs = attrs, fieldPub = pub)
         val rustReturnType = translateType(returnType, fn.returnType.pos)
+        // Optionals struct and impl next. We at least want optionals generics before requireds impl.
         val optionalGenerics = when {
             optionals.isEmpty() -> listOf()
             else -> {
                 // Manage optionals independently so they can default more easily.
-                val attrs = listOf(buildDerive(pos, listOf("Clone", "Default")))
-                val optionalGenerics = paramsToStructAdded(optionsId, optionals, attrs = attrs)
-                if (requireds.isEmpty()) {
-                    // If someone adds requireds later, then that's already breaking, so this is fine here.
-                    Rust.Impl(
-                        pos,
-                        generics = optionalGenerics.deepCopy(),
-                        trait = null,
-                        type = optionsId.makeTypeRef(optionalGenerics),
-                        items = buildList {
-                            Rust.Function(
-                                pos,
-                                id = "build".toId(pos),
-                                // Pass self by move on purpose in these, so we can avoid cloning.
-                                // We make builder types Clone in case anyone badly wants copies on their own.
-                                params = listOf(self),
-                                returnType = rustReturnType,
-                                block = Rust.Block(pos, result = callNew(optionals)),
-                            ).also { add(it.toItem(pub = pub)) }
-                        },
-                    ).also { moduleItems.add(it.toItem()) }
+                val attrs = listOf(buildDerive(pos, listOf("Clone")))
+                val selfishPlusOptionals = buildList {
+                    add(Rust.FunctionParam(pos, selfish.deepCopy(), builderId.makeTypeRef(filteredGenerics)))
+                    addAll(optionals)
                 }
-                optionalGenerics
-            }
-        }
-        if (requireds.isNotEmpty()) {
-            // Adding new requireds is a breaking change anyway, so presume this is also fixed in Rust.
-            val attrs = listOf(buildDerive(pos, listOf("Clone")))
-            val filteredGenerics = paramsToStructAdded(builderId, requireds, attrs = attrs)
-            // Adding new optionals *isn't* breaking, but adding a new related "options" field to requireds would be.
-            // So make a builder independent of optionals, and another that acknowledges them if present.
-            Rust.Impl(
-                pos,
-                generics = filteredGenerics.deepCopy(),
-                trait = null,
-                type = builderId.makeTypeRef(filteredGenerics),
-                items = buildList {
-                    Rust.Function(
-                        pos,
-                        id = "build".toId(pos),
-                        params = listOf(self),
-                        returnType = rustReturnType,
-                        block = Rust.Block(
-                            pos,
-                            result = when {
-                                // Just call the constructor if we only have requireds.
-                                optionals.isEmpty() -> callNew(requireds)
-                                // Delegate to the with-optionals builder.
-                                else -> self.deepCopy().methodCall(
-                                    key = "build_with",
-                                    args = listOf(makePath(pos, "std", "default", "Default", "default").call()),
-                                )
-                            },
-                        ),
-                    ).also { add(it.toItem(pub = pub)) }
-                    if (optionals.isNotEmpty()) {
-                        val optionsArg = "options".toId(pos)
+                val optionalGenerics = paramsToStructAdded(optionsId, selfishPlusOptionals, attrs = attrs)
+                Rust.Impl(
+                    pos,
+                    generics = optionalGenerics.deepCopy(),
+                    trait = null,
+                    type = optionsId.makeTypeRef(optionalGenerics),
+                    items = buildList {
+                        for (param in optionals) {
+                            param as Rust.FunctionParam
+                            // Undo optional for setter method params.
+                            val type = (param.type as? Rust.GenericType)?.args?.first() as Rust.Type?
+                            val paramId = param.pattern as Rust.Id
+                            Rust.Function(
+                                pos = param.pos,
+                                id = paramId.deepCopy(),
+                                params = listOf(
+                                    Rust.FunctionParam(
+                                        pos = param.pos,
+                                        pattern = Rust.IdPattern(pos, Rust.IdPatternMut(pos), self.deepCopy()),
+                                        type = null,
+                                    ),
+                                    Rust.FunctionParam(
+                                        pos = param.pos,
+                                        pattern = paramId.deepCopy(),
+                                        type = type,
+                                    ),
+                                ),
+                                returnType = "Self".toKeyId(param.pos),
+                                block = Rust.Block(
+                                    pos,
+                                    statements = Rust.ExprStatement(
+                                        param.pos,
+                                        Rust.Operation(
+                                            param.pos,
+                                            self.deepCopy().member(paramId.deepCopy(), notMethod = true),
+                                            Rust.Operator(pos, RustOperator.Assign),
+                                            paramId.deepCopy().wrapSome(),
+                                        ),
+                                    ).let { listOf(it) },
+                                    result = self.deepCopy(),
+                                ),
+                            ).also { add(it.toItem(pub = pub.deepCopy())) }
+                        }
                         Rust.Function(
                             pos,
-                            id = "build_with".toId(pos),
-                            generics = optionalGenerics.deepCopy(),
-                            params = listOf(
-                                self.deepCopy(),
-                                Rust.FunctionParam(pos, optionsArg, optionsId.makeTypeRef(optionalGenerics)),
-                            ),
-                            returnType = rustReturnType,
+                            id = "build".toId(pos),
+                            // Pass self by move on purpose in these, so we can avoid cloning.
+                            // We make builder types Clone in case anyone badly wants copies on their own.
+                            params = listOf(self.deepCopy()),
+                            returnType = rustReturnType.deepCopy(),
                             block = Rust.Block(
                                 pos,
                                 result = Rust.Call(
@@ -577,19 +476,64 @@ class RustTranslator(
                                     args = buildList {
                                         // Different subjects for each case here.
                                         for (param in requireds) {
-                                            add(self.deepCopy().member(param.toId(), notMethod = true))
+                                            val selfish = self.deepCopy().member("selfish")
+                                            add(selfish.member(param.toId(), notMethod = true))
                                         }
                                         for (param in optionals) {
-                                            add(optionsArg.deepCopy().member(param.toId(), notMethod = true))
+                                            add(self.deepCopy().member(param.toId(), notMethod = true))
                                         }
                                     },
                                 ),
                             ),
-                        ).also { add(it.toItem(pub = pub)) }
-                    }
-                },
-            ).also { moduleItems.add(it.toItem()) }
+                        ).also { add(it.toItem(pub = pub.deepCopy())) }
+                    },
+                ).also { builderItems.add(it.toItem()) }
+                optionalGenerics
+            }
         }
+        // Requireds impl.
+        // Adding new optionals *isn't* breaking, but adding a new related "options" field to requireds would be.
+        // So make a builder independent of optionals, and another that acknowledges them if present.
+        Rust.Impl(
+            pos,
+            generics = filteredGenerics.deepCopy(),
+            trait = null,
+            type = builderId.makeTypeRef(filteredGenerics),
+            items = buildList {
+                Rust.Function(
+                    pos,
+                    id = "build".toId(pos),
+                    params = listOf(self),
+                    returnType = rustReturnType,
+                    block = Rust.Block(
+                        pos,
+                        result = when {
+                            // Just call the constructor if we only have requireds.
+                            optionals.isEmpty() -> callNew(requireds)
+                            // Or else delegate to the optionals builder.
+                            else -> self.deepCopy().methodCall("options").methodCall("build")
+                        },
+                    ),
+                ).also { add(it.toItem(pub = pub)) }
+                if (optionals.isNotEmpty()) {
+                    Rust.Function(
+                        pos,
+                        id = "options".toId(pos),
+                        generics = optionalGenerics.deepCopy(),
+                        params = listOf(self.deepCopy()),
+                        returnType = optionsId.makeTypeRef(optionalGenerics),
+                        block = Rust.Block(
+                            pos,
+                            result = Rust.Call(
+                                pos,
+                                callee = optionsId.deepCopy().extendWith("new"),
+                                args = listOf(self.deepCopy()),
+                            ),
+                        ),
+                    ).also { add(it.toItem(pub = pub)) }
+                }
+            },
+        ).also { builderItems.add(it.toItem()) }
     }
 
     private fun processModuleFunctionDeclaration(decl: TmpL.ModuleFunctionDeclaration) {

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -379,14 +379,7 @@ class RustTranslator(
             // Work with Rust nodes rather than TmpL nodes because we already have generics handy in Rust form.
             // Any simple type name matching a formal has to be a reference to that formal.
             val usedTypes = params.findAllSimpleTypeNames()
-            val filteredGenerics = generics.filter { generic ->
-                val genericId = when (generic) {
-                    is Rust.Id -> generic
-                    is Rust.TypeParam -> generic.id
-                    else -> error(generic)
-                }.outName.outputNameText
-                genericId in usedTypes
-            }.deepCopy()
+            val filteredGenerics = generics.filter { it.lastIdText() in usedTypes }.deepCopy()
             Rust.Struct(
                 pos = pos,
                 id = id,
@@ -406,7 +399,7 @@ class RustTranslator(
         // Requireds struct first to get its generics.
         // Adding new requireds is a breaking change anyway, so presume this is also fixed in Rust.
         val attrs = listOf(buildDerive(pos, listOf("Clone")))
-        val filteredGenerics = paramsToStructAdded(builderId, requireds, attrs = attrs, fieldPub = pub)
+        val requiredGenerics = paramsToStructAdded(builderId, requireds, attrs = attrs, fieldPub = pub)
         val rustReturnType = translateType(returnType, fn.returnType.pos)
         // Optionals struct and impl next. We at least want optionals generics before requireds impl.
         val optionalGenerics = when {
@@ -414,7 +407,7 @@ class RustTranslator(
             else -> {
                 // Manage optionals independently so they can default more easily.
                 val attrs = listOf(buildDerive(pos, listOf("Clone")))
-                val selfishParam = Rust.FunctionParam(pos, selfish.deepCopy(), builderId.makeTypeRef(filteredGenerics))
+                val selfishParam = Rust.FunctionParam(pos, selfish.deepCopy(), builderId.makeTypeRef(requiredGenerics))
                 val selfishPlusOptionals = buildList {
                     add(selfishParam)
                     addAll(optionals)
@@ -485,6 +478,7 @@ class RustTranslator(
                         Rust.Function(
                             pos,
                             id = "build".toId(pos),
+                            generics = generics.except(optionalGenerics),
                             // Pass self by move on purpose in these, so we can avoid cloning.
                             // We make builder types Clone in case anyone badly wants copies on their own.
                             params = listOf(self.deepCopy()),
@@ -517,13 +511,14 @@ class RustTranslator(
         // So make a builder independent of optionals, and another that acknowledges them if present.
         Rust.Impl(
             pos,
-            generics = filteredGenerics.deepCopy(),
+            generics = requiredGenerics.deepCopy(),
             trait = null,
-            type = builderId.makeTypeRef(filteredGenerics),
+            type = builderId.makeTypeRef(requiredGenerics),
             items = buildList {
                 Rust.Function(
                     pos,
                     id = "build".toId(pos),
+                    generics = generics.except(requiredGenerics),
                     params = listOf(self),
                     returnType = rustReturnType,
                     block = Rust.Block(
@@ -540,7 +535,7 @@ class RustTranslator(
                     Rust.Function(
                         pos,
                         id = "options".toId(pos),
-                        generics = optionalGenerics.deepCopy(),
+                        generics = optionalGenerics.except(requiredGenerics),
                         params = listOf(self.deepCopy()),
                         returnType = optionsId.makeTypeRef(optionalGenerics),
                         block = Rust.Block(

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -418,7 +418,12 @@ class RustTranslator(
                             params = listOf(
                                 Rust.FunctionParam(
                                     pos = param.pos,
-                                    pattern = Rust.IdPattern(pos, Rust.IdPatternMut(pos), paramId.deepCopy()),
+                                    pattern = Rust.IdPattern(pos, Rust.IdPatternMut(pos), self.deepCopy()),
+                                    type = null,
+                                ),
+                                Rust.FunctionParam(
+                                    pos = param.pos,
+                                    pattern = paramId.deepCopy(),
                                     type = type,
                                 ),
                             ),

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -187,7 +187,7 @@ class RustTranslator(
                             pos,
                             id = "builders".toId(pos), // TODO Uniqueness?
                             block = Rust.Block(pos, statements = builderItems),
-                        ).toItem().also { add(it) }
+                        ).toItem(pub = Rust.VisibilityPub(pos)).also { add(it) }
                     }
                     // Tests.
                     if (testItems.isNotEmpty()) {

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -368,6 +368,7 @@ class RustTranslator(
         }.let { (requireds, optionals) ->
             requireds.map { it.second } to optionals.map { it.second }
         }
+        val self = "self".toKeyId(pos)
         fun paramsToStructAddedChain(): List<Rust.GenericParam> {
             val id = builderId.deepCopy() // TODO Stop the deepCopy later.
             val params = rustParams
@@ -391,11 +392,72 @@ class RustTranslator(
                     param as Rust.FunctionParam
                     val type = when {
                         tmpl.optional -> param.type
+                        // Add optional for storage.
                         else -> param.type?.deepCopy()?.option()
                     }
                     Rust.StructField(param.pos, pub = pub, id = param.pattern as Rust.Id, type = type)
                 },
             ).also { builderItems.add(it.toItem(attrs = attrs, pub = pub)) }
+            Rust.Impl(
+                pos = pos,
+                generics = filteredGenerics.deepCopy(),
+                trait = null,
+                type = builderId.makeTypeRef(filteredGenerics),
+                items = buildList methods@{
+                    for ((tmpl, param) in paramPairs) {
+                        param as Rust.FunctionParam
+                        val type = when {
+                            // Undo optional for setter method params.
+                            tmpl.optional -> (param.type as? Rust.GenericType)?.args?.first() as Rust.Type?
+                            else -> param.type
+                        }?.deepCopy()
+                        val paramId = param.pattern as Rust.Id
+                        Rust.Function(
+                            pos = param.pos,
+                            id = paramId.deepCopy(),
+                            params = listOf(
+                                Rust.FunctionParam(
+                                    pos = param.pos,
+                                    pattern = Rust.IdPattern(pos, Rust.IdPatternMut(pos), paramId.deepCopy()),
+                                    type = type,
+                                ),
+                            ),
+                            returnType = "Self".toKeyId(param.pos),
+                            block = Rust.Block(
+                                pos,
+                                statements = Rust.ExprStatement(
+                                    param.pos,
+                                    Rust.Operation(
+                                        param.pos,
+                                        self.deepCopy().member(paramId.deepCopy(), notMethod = true),
+                                        Rust.Operator(pos, RustOperator.Assign),
+                                        paramId.deepCopy().wrapSome(),
+                                    ),
+                                ).let { listOf(it) },
+                                result = self.deepCopy(),
+                            ),
+                        ).also { this@methods.add(it.toItem()) }
+                    }
+//                    Rust.Function(
+//                        pos,
+//                        id = "build".toId(pos),
+//                        params = listOf(self),
+//                        returnType = rustReturnType,
+//                        block = Rust.Block(
+//                            pos,
+//                            result = when {
+//                                // Just call the constructor if we only have requireds.
+//                                optionals.isEmpty() -> callNew(requireds)
+//                                // Delegate to the with-optionals builder.
+//                                else -> self.deepCopy().methodCall(
+//                                    key = "build_with",
+//                                    args = listOf(makePath(pos, "std", "default", "Default", "default").call()),
+//                                )
+//                            },
+//                        ),
+//                    ).also { add(it.toItem(pub = pub)) }
+                }
+            ).also { builderItems.add(it.toItem()) }
             return filteredGenerics
         }
         paramsToStructAddedChain()
@@ -426,7 +488,6 @@ class RustTranslator(
             ).also { moduleItems.add(it.toItem(attrs = attrs, pub = pub)) }
             return filteredGenerics
         }
-        val self = "self".toKeyId(pos)
         fun callNew(params: List<Rust.FunctionParamOption>) = Rust.Call(
             pos,
             callee = targetId.deepCopy().extendWith("new"),

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1248,11 +1248,11 @@ class RustBackendTest {
                 |        pub x: Option<std::sync::Arc<String>>, pub y: Option<std::sync::Arc<String>>
                 |    }
                 |    impl CBuilder {
-                |        fn x(mut x: std::sync::Arc<String>) -> Self {
+                |        fn x(mut self, x: std::sync::Arc<String>) -> Self {
                 |            self.x = Some(x);
                 |            self
                 |        }
-                |        fn y(mut y: std::sync::Arc<String>) -> Self {
+                |        fn y(mut self, y: std::sync::Arc<String>) -> Self {
                 |            self.y = Some(y);
                 |            self
                 |        }
@@ -1850,11 +1850,11 @@ class RustBackendTest {
                 |        pub i: Option<i32>, pub j: Option<i32>
                 |    }
                 |    impl HaBuilder {
-                |        fn i(mut i: i32) -> Self {
+                |        fn i(mut self, i: i32) -> Self {
                 |            self.i = Some(i);
                 |            self
                 |        }
-                |        fn j(mut j: i32) -> Self {
+                |        fn j(mut self, j: i32) -> Self {
                 |            self.j = Some(j);
                 |            self
                 |        }
@@ -1937,15 +1937,15 @@ class RustBackendTest {
                 |        pub t: Option<Option<T>>, pub u: Option<U>, pub i: Option<i32>
                 |    }
                 |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiBuilder<T, U> {
-                |        fn t(mut t: Option<T>) -> Self {
+                |        fn t(mut self, t: Option<T>) -> Self {
                 |            self.t = Some(t);
                 |            self
                 |        }
-                |        fn u(mut u: U) -> Self {
+                |        fn u(mut self, u: U) -> Self {
                 |            self.u = Some(u);
                 |            self
                 |        }
-                |        fn i(mut i: i32) -> Self {
+                |        fn i(mut self, i: i32) -> Self {
                 |            self.i = Some(i);
                 |            self
                 |        }
@@ -2242,11 +2242,11 @@ class RustBackendTest {
             |        pub x: Option<f64>, pub y: Option<f64>
             |    }
             |    impl Vec2Builder {
-            |        fn x(mut x: f64) -> Self {
+            |        fn x(mut self, x: f64) -> Self {
             |            self.x = Some(x);
             |            self
             |        }
-            |        fn y(mut y: f64) -> Self {
+            |        fn y(mut self, y: f64) -> Self {
             |            self.y = Some(y);
             |            self
             |        }

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1827,7 +1827,7 @@ class RustBackendTest {
                 |        pub i: i32, pub j: i32
                 |    }
                 |    impl HaBuilder {
-                |        pub fn build(self) -> Ha<T> {
+                |        pub fn build<T: Clone + std::marker::Send + std::marker::Sync + 'static>(self) -> Ha<T> {
                 |            Ha::new(self.i, self.j)
                 |        }
                 |    }
@@ -1914,7 +1914,7 @@ class RustBackendTest {
                 |        pub fn build(self) -> Hi<T, U> {
                 |            self.options().build()
                 |        }
-                |        pub fn options<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static>(self) -> HiOptions<T, U> {
+                |        pub fn options(self) -> HiOptions<T, U> {
                 |            HiOptions::new(self)
                 |        }
                 |    }

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1888,22 +1888,6 @@ class RustBackendTest {
                 |}
                 |#[derive(Clone)]
                 |pub struct Hi<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static>(std::sync::Arc<HiStruct<T, U>>);
-                |#[derive(Clone, Default)]
-                |pub struct HiOptions {
-                |    pub i: Option<i32>
-                |}
-                |#[derive(Clone)]
-                |pub struct HiBuilder<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> {
-                |    pub t: Option<T>, pub u: U
-                |}
-                |impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiBuilder<T, U> {
-                |    pub fn build(self) -> Hi<T, U> {
-                |        self.build_with(std::default::Default::default())
-                |    }
-                |    pub fn build_with(self, options: HiOptions) -> Hi<T, U> {
-                |        Hi::new(self.t, self.u, options.i)
-                |    }
-                |}
                 |impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> Hi<T, U> {
                 |    pub fn new(t__0: Option<T>, u__0: U, i__0: Option<i32>) -> Hi<T, U> {
                 |        let t;
@@ -1932,22 +1916,29 @@ class RustBackendTest {
                 |}
                 |temper_core::impl_any_value_trait!(Hi<T, U>, [] where U: std::cmp::Eq + std::hash::Hash);
                 |mod builders {
-                |    #[derive(Clone, Default)]
+                |    #[derive(Clone)]
                 |    pub struct HiBuilder<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> {
-                |        pub t: Option<Option<T>>, pub u: Option<U>, pub i: Option<i32>
+                |        pub t: Option<T>, pub u: U
                 |    }
-                |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiBuilder<T, U> {
-                |        fn t(mut self, t: Option<T>) -> Self {
-                |            self.t = Some(t);
-                |            self
-                |        }
-                |        fn u(mut self, u: U) -> Self {
-                |            self.u = Some(u);
-                |            self
-                |        }
-                |        fn i(mut self, i: i32) -> Self {
+                |    #[derive(Clone)]
+                |    pub struct HiOptions<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> {
+                |        selfish: HiBuilder<T, U>, i: Option<i32>
+                |    }
+                |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiOptions<T, U> {
+                |        pub fn i(mut self, i: i32) -> Self {
                 |            self.i = Some(i);
                 |            self
+                |        }
+                |        pub fn build(self) -> Hi<T, U> {
+                |            Hi::new(self.selfish.t, self.selfish.u, self.i)
+                |        }
+                |    }
+                |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiBuilder<T, U> {
+                |        pub fn build(self) -> Hi<T, U> {
+                |            self.options().build()
+                |        }
+                |        pub fn options<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static>(self) -> HiOptions<T, U> {
+                |            HiOptions::new(self)
                 |        }
                 |    }
                 |    use super::*;

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1247,6 +1247,16 @@ class RustBackendTest {
                 |    pub struct CBuilder {
                 |        pub x: Option<std::sync::Arc<String>>, pub y: Option<std::sync::Arc<String>>
                 |    }
+                |    impl CBuilder {
+                |        fn x(mut x: std::sync::Arc<String>) -> Self {
+                |            self.x = Some(x);
+                |            self
+                |        }
+                |        fn y(mut y: std::sync::Arc<String>) -> Self {
+                |            self.y = Some(y);
+                |            self
+                |        }
+                |    }
                 |    use super::*;
                 |}
             """.trimMargin(),
@@ -1834,6 +1844,23 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Ha<T>, []);
+                |mod builders {
+                |    #[derive(Clone, Default)]
+                |    pub struct HaBuilder {
+                |        pub i: Option<i32>, pub j: Option<i32>
+                |    }
+                |    impl HaBuilder {
+                |        fn i(mut i: i32) -> Self {
+                |            self.i = Some(i);
+                |            self
+                |        }
+                |        fn j(mut j: i32) -> Self {
+                |            self.j = Some(j);
+                |            self
+                |        }
+                |    }
+                |    use super::*;
+                |}
             """.trimMargin(),
         )
     }
@@ -1904,6 +1931,27 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Hi<T, U>, [] where U: std::cmp::Eq + std::hash::Hash);
+                |mod builders {
+                |    #[derive(Clone, Default)]
+                |    pub struct HiBuilder<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> {
+                |        pub t: Option<Option<T>>, pub u: Option<U>, pub i: Option<i32>
+                |    }
+                |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiBuilder<T, U> {
+                |        fn t(mut t: Option<T>) -> Self {
+                |            self.t = Some(t);
+                |            self
+                |        }
+                |        fn u(mut u: U) -> Self {
+                |            self.u = Some(u);
+                |            self
+                |        }
+                |        fn i(mut i: i32) -> Self {
+                |            self.i = Some(i);
+                |            self
+                |        }
+                |    }
+                |    use super::*;
+                |}
             """.trimMargin(),
         )
     }
@@ -2188,6 +2236,23 @@ class RustBackendTest {
             |    }
             |}
             |temper_core::impl_any_value_trait!(Vec2, []);
+            |mod builders {
+            |    #[derive(Clone, Default)]
+            |    pub struct Vec2Builder {
+            |        pub x: Option<f64>, pub y: Option<f64>
+            |    }
+            |    impl Vec2Builder {
+            |        fn x(mut x: f64) -> Self {
+            |            self.x = Some(x);
+            |            self
+            |        }
+            |        fn y(mut y: f64) -> Self {
+            |            self.y = Some(y);
+            |            self
+            |        }
+            |    }
+            |    use super::*;
+            |}
         """.trimMargin(),
     )
 

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1184,15 +1184,6 @@ class RustBackendTest {
                 |}
                 |#[derive(Clone)]
                 |pub struct C(std::sync::Arc<std::sync::RwLock<CStruct>>);
-                |#[derive(Clone)]
-                |pub struct CBuilder {
-                |    pub x: std::sync::Arc<String>, pub y: std::sync::Arc<String>
-                |}
-                |impl CBuilder {
-                |    pub fn build(self) -> C {
-                |        C::new(self.x, self.y)
-                |    }
-                |}
                 |impl C {
                 |    pub fn v(& self) -> std::sync::Arc<String> {
                 |        return std::sync::Arc::new("ciao".to_string());
@@ -1243,18 +1234,13 @@ class RustBackendTest {
                 |}
                 |temper_core::impl_any_value_trait!(C, []);
                 |mod builders {
-                |    #[derive(Clone, Default)]
+                |    #[derive(Clone)]
                 |    pub struct CBuilder {
-                |        pub x: Option<std::sync::Arc<String>>, pub y: Option<std::sync::Arc<String>>
+                |        pub x: std::sync::Arc<String>, pub y: std::sync::Arc<String>
                 |    }
                 |    impl CBuilder {
-                |        fn x(mut self, x: std::sync::Arc<String>) -> Self {
-                |            self.x = Some(x);
-                |            self
-                |        }
-                |        fn y(mut self, y: std::sync::Arc<String>) -> Self {
-                |            self.y = Some(y);
-                |            self
+                |        pub fn build(self) -> C {
+                |            C::new(self.x, self.y)
                 |        }
                 |    }
                 |    use super::*;
@@ -1816,15 +1802,6 @@ class RustBackendTest {
                 |}
                 |#[derive(Clone)]
                 |pub struct Ha<T: Clone + std::marker::Send + std::marker::Sync + 'static>(std::sync::Arc<HaStruct<T>>);
-                |#[derive(Clone)]
-                |pub struct HaBuilder {
-                |    pub i: i32, pub j: i32
-                |}
-                |impl HaBuilder {
-                |    pub fn build(self) -> Ha<T> {
-                |        Ha::new(self.i, self.j)
-                |    }
-                |}
                 |impl<T: Clone + std::marker::Send + std::marker::Sync + 'static> Ha<T> {
                 |    pub fn new(i__0: i32, j__0: i32) -> Ha<T> {
                 |        let i;
@@ -1845,18 +1822,13 @@ class RustBackendTest {
                 |}
                 |temper_core::impl_any_value_trait!(Ha<T>, []);
                 |mod builders {
-                |    #[derive(Clone, Default)]
+                |    #[derive(Clone)]
                 |    pub struct HaBuilder {
-                |        pub i: Option<i32>, pub j: Option<i32>
+                |        pub i: i32, pub j: i32
                 |    }
                 |    impl HaBuilder {
-                |        fn i(mut self, i: i32) -> Self {
-                |            self.i = Some(i);
-                |            self
-                |        }
-                |        fn j(mut self, j: i32) -> Self {
-                |            self.j = Some(j);
-                |            self
+                |        pub fn build(self) -> Ha<T> {
+                |            Ha::new(self.i, self.j)
                 |        }
                 |    }
                 |    use super::*;
@@ -1925,6 +1897,11 @@ class RustBackendTest {
                 |        selfish: HiBuilder<T, U>, i: Option<i32>
                 |    }
                 |    impl<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> HiOptions<T, U> {
+                |        pub fn new(selfish: HiBuilder<T, U>) -> Self {
+                |            Self {
+                |                selfish, i: None
+                |            }
+                |        }
                 |        pub fn i(mut self, i: i32) -> Self {
                 |            self.i = Some(i);
                 |            self
@@ -2187,15 +2164,6 @@ class RustBackendTest {
             |}
             |#[derive(Clone)]
             |pub struct Vec2(std::sync::Arc<Vec2Struct>);
-            |#[derive(Clone, Default)]
-            |pub struct Vec2Options {
-            |    pub x: Option<f64>, pub y: Option<f64>
-            |}
-            |impl Vec2Options {
-            |    pub fn build(self) -> Vec2 {
-            |        Vec2::new(self.x, self.y)
-            |    }
-            |}
             |impl Vec2 {
             |    pub fn new(x__0: Option<f64>, y__0: Option<f64>) -> Vec2 {
             |        let x;
@@ -2228,18 +2196,36 @@ class RustBackendTest {
             |}
             |temper_core::impl_any_value_trait!(Vec2, []);
             |mod builders {
-            |    #[derive(Clone, Default)]
-            |    pub struct Vec2Builder {
-            |        pub x: Option<f64>, pub y: Option<f64>
+            |    #[derive(Clone)]
+            |    pub struct Vec2Builder {}
+            |    #[derive(Clone)]
+            |    pub struct Vec2Options {
+            |        selfish: Vec2Builder, x: Option<f64>, y: Option<f64>
             |    }
-            |    impl Vec2Builder {
-            |        fn x(mut self, x: f64) -> Self {
+            |    impl Vec2Options {
+            |        pub fn new(selfish: Vec2Builder) -> Self {
+            |            Self {
+            |                selfish, x: None, y: None
+            |            }
+            |        }
+            |        pub fn x(mut self, x: f64) -> Self {
             |            self.x = Some(x);
             |            self
             |        }
-            |        fn y(mut self, y: f64) -> Self {
+            |        pub fn y(mut self, y: f64) -> Self {
             |            self.y = Some(y);
             |            self
+            |        }
+            |        pub fn build(self) -> Vec2 {
+            |            Vec2::new(self.x, self.y)
+            |        }
+            |    }
+            |    impl Vec2Builder {
+            |        pub fn build(self) -> Vec2 {
+            |            self.options().build()
+            |        }
+            |        pub fn options(self) -> Vec2Options {
+            |            Vec2Options::new(self)
             |        }
             |    }
             |    use super::*;

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1242,6 +1242,13 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(C, []);
+                |mod builders {
+                |    #[derive(Clone, Default)]
+                |    pub struct CBuilder {
+                |        pub x: Option<std::sync::Arc<String>>, pub y: Option<std::sync::Arc<String>>
+                |    }
+                |    use super::*;
+                |}
             """.trimMargin(),
         )
     }

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -1233,7 +1233,7 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(C, []);
-                |mod builders {
+                |pub mod builders {
                 |    #[derive(Clone)]
                 |    pub struct CBuilder {
                 |        pub x: std::sync::Arc<String>, pub y: std::sync::Arc<String>
@@ -1821,7 +1821,7 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Ha<T>, []);
-                |mod builders {
+                |pub mod builders {
                 |    #[derive(Clone)]
                 |    pub struct HaBuilder {
                 |        pub i: i32, pub j: i32
@@ -1887,7 +1887,7 @@ class RustBackendTest {
                 |    }
                 |}
                 |temper_core::impl_any_value_trait!(Hi<T, U>, [] where U: std::cmp::Eq + std::hash::Hash);
-                |mod builders {
+                |pub mod builders {
                 |    #[derive(Clone)]
                 |    pub struct HiBuilder<T: Clone + std::marker::Send + std::marker::Sync + 'static, U: std::cmp::Eq + std::hash::Hash + Clone + std::marker::Send + std::marker::Sync + 'static> {
                 |        pub t: Option<T>, pub u: U
@@ -2195,7 +2195,7 @@ class RustBackendTest {
             |    }
             |}
             |temper_core::impl_any_value_trait!(Vec2, []);
-            |mod builders {
+            |pub mod builders {
             |    #[derive(Clone)]
             |    pub struct Vec2Builder {}
             |    #[derive(Clone)]

--- a/functional-test-suite/src/commonMain/resources/classes/object-literals/object-literals.temper.md
+++ b/functional-test-suite/src/commonMain/resources/classes/object-literals/object-literals.temper.md
@@ -10,9 +10,9 @@ We infer the constructor by matching up property names.
 
 Define local types, too. We'll import other types syntactically further down.
 
-    class Person(
+    export class Person( // export for exploring generated builders
       public name: String,
-      public age: Int,
+      public age: Int = -100, // mostly just for exploring be-rust codegen
     ) extends Stringable {
       public toString(): String {
 

--- a/functional-test-suite/src/commonMain/resources/functions/named-args/named-args.temper.md
+++ b/functional-test-suite/src/commonMain/resources/functions/named-args/named-args.temper.md
@@ -12,7 +12,7 @@ but named values only work for constructing class instances.
 So make an abusive class that has a constructor only for side effects, so we
 can see what happens.
 
-    class Greet {
+    export class Greet { // export for exploring generated builders
       public constructor(
         @noProperty message: String = "Hi!",
         @noProperty repeat: Boolean = false,


### PR DESCRIPTION
- Fix #367.
- Put builders in `builders` submodule to isolate the generated name better, even though name collisions could still happen so far (such as for a manually named `builders` submodule).
- Fix some issues with generics.
- Use method chaining for optionals as better future proofing.
- I still haven't made a `Whatever::builder()` convenience as recommended in #367, but the most important changes are here, and we can get back to that later if we want. It's another place for potential name collision, though.
- I also considered going with `...::builders::Whatever` instead of `...::builders::WhateverBuilder`, but I figured some people might want to `use` the `builders` directly into scope, and that would be a bit simpler without the namespace collision of saying just `Whatever`.