### PR TITLE
Panic (correctly now?) on missing else for exhaustive sealed when

### DIFF
--- a/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
+++ b/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
@@ -133,7 +133,7 @@ class PyBackendTest {
             |var m: MapBuilder<String, Int>? = null;
             |for (let e of [1, 2, 3]) {
             |  if (e == 2) {
-            |    m = new MapBuilder<String, Int>()
+            |    m = new MapBuilder<String, Int>();
             |  }
             |}
             |if (m is MapBuilder<String, Int>) {

--- a/builtin/src/commonMain/kotlin/lang/temper/builtin/BuiltinFuns.kt
+++ b/builtin/src/commonMain/kotlin/lang/temper/builtin/BuiltinFuns.kt
@@ -59,6 +59,7 @@ import lang.temper.value.TList
 import lang.temper.value.TNull
 import lang.temper.value.TString
 import lang.temper.value.Value
+import lang.temper.value.VoidishPanicFn
 import lang.temper.value.helpSnippet
 import lang.temper.value.listBuiltinName
 import lang.temper.value.or
@@ -2007,6 +2008,7 @@ object BuiltinFuns {
     val handlerScope: MacroValue = HandlerScopeFn
     val bubble: NamedBuiltinFun = BubbleFn
     val panic: NamedBuiltinFun = PanicFn
+    val voidishPanic: NamedBuiltinFun = VoidishPanicFn
 
     val makeClosRec: MacroValue = MakeClosRec
     val getCR: CallableValue = GetCR
@@ -2026,6 +2028,7 @@ object BuiltinFuns {
     val vCharTagFn = Value(charTagFn)
     val vBubble = Value(bubble)
     val vPanic = Value(panic)
+    val vVoidishPanic = Value(voidishPanic)
     val vCmp = Value(cmpFn)
     val vCommaFn = Value(commaFn)
     val vMinusFn = Value(minusFn)

--- a/cli/src/test/kotlin/lang/temper/cli/repl/ReplTest.kt
+++ b/cli/src/test/kotlin/lang/temper/cli/repl/ReplTest.kt
@@ -636,9 +636,9 @@ class ReplTest {
         repl.processLine("let hi(i: Int): Int { when (i) { 1 -> 1 } }")
         assertPending(
             """
-                |1: t hi(i: Int): Int { when (i) { 1 -> 1 } }
-                |                       ┗━━━━━━━━━━━━━━━━━┛
-                |[interactive#0:1+22-41]@G: Cannot assign to Int32 from Void
+                |1: when (i) { 1 -> 1 } }
+                |                      ⇧
+                |[interactive#0:1+41]@G: Cannot assign to Int32 from Void
                 |interactive#0: void
                 |
             """.trimMargin(),

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
@@ -162,7 +162,11 @@ internal class TypeStage(
         }
 
         // With type info, we can finalize `else` values.
-        replaceVoidishPanics(root)
+        Debug.Frontend.TypeStage.ReplaceVoidishPanics(configKey)
+            .benchmarkIf(BENCHMARK, "ReplaceVoidishPanics") {
+                replaceVoidishPanics(root)
+            }
+        Debug.Frontend.TypeStage.AfterReplaceVoidishPanics.snapshot(configKey, AstSnapshotKey, root)
 
         if (genre != Genre.Documentation) {
             Debug.Frontend.TypeStage.UseBeforeInit(configKey)

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
@@ -1,6 +1,8 @@
 package lang.temper.frontend.typestage
 
 import lang.temper.ast.TreeVisit
+import lang.temper.ast.VisitCue
+import lang.temper.builtin.BuiltinFuns
 import lang.temper.common.Console
 import lang.temper.common.benchmarkIf
 import lang.temper.common.calledFor
@@ -26,11 +28,19 @@ import lang.temper.log.snapshot
 import lang.temper.name.ResolvedName
 import lang.temper.stage.Stage
 import lang.temper.type.InvalidType
+import lang.temper.type.NominalType
 import lang.temper.type.StaticType
+import lang.temper.type.WellKnownTypes
+import lang.temper.value.BasicTypeInferences
 import lang.temper.value.BlockTree
+import lang.temper.value.CallTree
 import lang.temper.value.TBoolean
 import lang.temper.value.Tree
+import lang.temper.value.VoidishPanicFn
+import lang.temper.value.functionContained
+import lang.temper.value.staticTypeContained
 import lang.temper.value.toLispy
+import lang.temper.value.void
 import lang.temper.value.InterpreterCallback.NullInterpreterCallback as nullCallback
 
 private const val BENCHMARK = true
@@ -152,6 +162,9 @@ internal class TypeStage(
             dumpMissingTypeInfo(root, "After typer", console)
         }
 
+        // With type info, we can finalize `else` values.
+        replaceVoidishPanics(root)
+
         if (genre != Genre.Documentation) {
             Debug.Frontend.TypeStage.UseBeforeInit(configKey)
                 .benchmarkIf(BENCHMARK, "UseBeforeInit") {
@@ -251,4 +264,44 @@ private fun dumpMissingTypeInfo(ast: Tree, description: String, console: Console
             }
         }
     }
+}
+
+/**
+ * Replace voidish panics with either void or panic.
+ * TODO Flow typing would be more general than this.
+ */
+private fun replaceVoidishPanics(root: BlockTree) {
+    val expectedTreeSize = VoidishPanicFn.sigs.first().requiredInputTypes.size + 1
+    TreeVisit.startingAt(root).forEach tree@{ tree ->
+        tree is CallTree || return@tree VisitCue.Continue
+        tree.size == expectedTreeSize || return@tree VisitCue.Continue
+        tree.child(0).functionContained == VoidishPanicFn || return@tree VisitCue.Continue
+        // From here down, we know we need either void or standard panic.
+        val incoming = tree.incoming
+        incoming?.replace {
+            run exhaustive@{
+                // Check fail bailing with null goes to void below.
+                val foundType = tree.child(1).typeInferences?.type ?: return@exhaustive null
+                val expectedType = tree.child(2).staticTypeContained ?: return@exhaustive null
+                foundType is NominalType && expectedType is NominalType || return@exhaustive null
+                // We don't support subtyping the same interface under different type actuals,
+                // so simple subtyping is fine here. Any broken type actuals will cause static
+                // type errors elsewhere.
+                isSimpleSubtype(foundType, expectedType) || return@exhaustive null
+                // Passed all checks, so panic it is.
+                Call(tree.typeInferences) { V(BuiltinFuns.vPanic) }
+            } ?: run {
+                // Or bail here to void on check fails.
+                V(void, WellKnownTypes.voidType)
+            }
+        }
+        // Either way, these calls are effectively leaves, so don't bother with kids.
+        VisitCue.SkipOne
+    }.visitPreOrder() // Ok because we never recurse target kids.
+}
+
+/** Just checks for same or subtype, ignoring type actuals. */
+private fun isSimpleSubtype(sub: NominalType, sup: NominalType): Boolean {
+    sub.definition == sup.definition && return true
+    return sub.definition.superTypes.any { isSimpleSubtype(it, sup) }
 }

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
@@ -288,7 +288,7 @@ private fun replaceVoidishPanics(root: BlockTree) {
                 // type errors elsewhere.
                 isSimpleSubtype(foundType, expectedType) || return@exhaustive null
                 // Passed all checks, so panic it is.
-                Call(tree.typeInferences) { V(BuiltinFuns.vPanic) }
+                Call(BuiltinFuns.vPanic, tree.typeInferences) {}
             } ?: run {
                 // Or bail here to void on check fails.
                 V(void, WellKnownTypes.voidType)

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/typestage/TypeStage.kt
@@ -31,7 +31,6 @@ import lang.temper.type.InvalidType
 import lang.temper.type.NominalType
 import lang.temper.type.StaticType
 import lang.temper.type.WellKnownTypes
-import lang.temper.value.BasicTypeInferences
 import lang.temper.value.BlockTree
 import lang.temper.value.CallTree
 import lang.temper.value.TBoolean

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
@@ -147,16 +147,13 @@ class GenerateCodeStageTest {
             |          } else if (is(s__0, Square)) {
             |            return__4 = "square"
             |          } else {
-            |            return__4 = void
+            |            return__4 = panic ⋖ String ⋗()
             |          }
             |      })
             |
             |      ```
             |  },
             |  errors: [
-            |    "Cannot assign to String from Void!",
-            |    "Expected subtype of String, but got Void!",
-            |    "Void expressions cannot be used as values!",
             |    "Cannot assign to String from Void!",
             |    "Expected subtype of String, but got Void!",
             |    "Void expressions cannot be used as values!",
@@ -2942,9 +2939,7 @@ class GenerateCodeStageTest {
             |          return__0 = do_get_end(s__0)
             |      });
             |      f__0 = (@stay fn f(s__1 /* aka s */: String) /* return__1 */: Boolean {
-            |          let t#0;
-            |          t#0 = (fn g)(s__1);
-            |          return__1 = is(t#0, NoStringIndex)
+            |          return__1 = is((fn g)(s__1), NoStringIndex)
             |      })
             |
             |      ```

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
@@ -133,16 +133,22 @@ class GenerateCodeStageTest {
             |          return__2 = void
             |      });
             |      `test//`.describeGeometric = (@stay fn describeGeometric(g__0 /* aka g */: Geometric) /* return__3 */: String {
-            |          if (!is(g__0, Circle)) {
-            |            if (is(g__0, Square)) {}
-            |          };
-            |          return__3 = void
+            |          if (is(g__0, Circle)) {
+            |            return__3 = "circle"
+            |          } else if (is(g__0, Square)) {
+            |            return__3 = "square"
+            |          } else {
+            |            return__3 = void
+            |          }
             |      });
             |      `test//`.describeShape = (@stay fn describeShape(s__0 /* aka s */: Shape) /* return__4 */: String {
-            |          if (!is(s__0, Circle)) {
-            |            if (is(s__0, Square)) {}
-            |          };
-            |          return__4 = void
+            |          if (is(s__0, Circle)) {
+            |            return__4 = "circle"
+            |          } else if (is(s__0, Square)) {
+            |            return__4 = "square"
+            |          } else {
+            |            return__4 = void
+            |          }
             |      })
             |
             |      ```

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/GenerateCodeStageTest.kt
@@ -77,6 +77,89 @@ class GenerateCodeStageTest {
     )
 
     @Test
+    fun sealedWhen() = assertModuleAtStage(
+        stage = Stage.GenerateCode,
+        pseudoCodeDetail = PseudoCodeDetail.default.copy(showInferredTypes = true),
+        input = """
+            |export interface Geometric {}
+            |export class Ray extends Geometric {}
+            |export sealed interface Shape extends Geometric {}
+            |export class Circle() extends Shape {}
+            |export class Square() extends Shape {}
+            |export let describeGeometric(g: Geometric): String {
+            |  when (g) {
+            |    is Circle -> "circle";
+            |    is Square -> "square";
+            |    // defaults to void here because it starts above the sealed type
+            |  }
+            |}
+            |export let describeShape(s: Shape): String {
+            |  when (s) {
+            |    is Circle -> "circle";
+            |    is Square -> "square";
+            |    // defaults to panic here because those are exhaustive for Shape
+            |  }
+            |}
+        """.trimMargin(),
+        want = """
+            |{
+            |  generateCode: {
+            |    body:
+            |      ```
+            |      @typeDecl(Geometric) @stay let `test//`.Geometric ⦂ Type;
+            |      `test//`.Geometric = type (Geometric);
+            |      @typeDecl(Ray) @stay let `test//`.Ray ⦂ Type;
+            |      `test//`.Ray = type (Ray);
+            |      @typeDecl(Shape) @stay @sealedType let `test//`.Shape ⦂ Type;
+            |      `test//`.Shape = type (Shape);
+            |      @typeDecl(Circle) @stay let `test//`.Circle ⦂ Type;
+            |      `test//`.Circle = type (Circle);
+            |      @typeDecl(Square) @stay let `test//`.Square ⦂ Type;
+            |      `test//`.Square = type (Square);
+            |      @fn let `test//`.describeGeometric ⦂(fn (Geometric): String), @fn `test//`.describeShape ⦂(fn (Shape): String), @typePlaceholder(Geometric) typePlaceholder#0: Empty;
+            |      typePlaceholder#0 = {class: Empty__0};
+            |      @fn @visibility(\public) @stay @fromType(Ray) let constructor__0 ⦂(fn (Ray): Void);
+            |      constructor__0 = (@stay fn constructor(@impliedThis(Ray) this__0: Ray) /* return__0 */: Void {
+            |          return__0 = void
+            |      });
+            |      @typePlaceholder(Shape) let typePlaceholder#1: Empty;
+            |      typePlaceholder#1 = {class: Empty__0};
+            |      @fn @visibility(\public) @stay @fromType(Circle) let constructor__1 ⦂(fn (Circle): Void);
+            |      constructor__1 = (@stay fn constructor(@impliedThis(Circle) this__1: Circle) /* return__1 */: Void {
+            |          return__1 = void
+            |      });
+            |      @fn @visibility(\public) @stay @fromType(Square) let constructor__2 ⦂(fn (Square): Void);
+            |      constructor__2 = (@stay fn constructor(@impliedThis(Square) this__2: Square) /* return__2 */: Void {
+            |          return__2 = void
+            |      });
+            |      `test//`.describeGeometric = (@stay fn describeGeometric(g__0 /* aka g */: Geometric) /* return__3 */: String {
+            |          if (!is(g__0, Circle)) {
+            |            if (is(g__0, Square)) {}
+            |          };
+            |          return__3 = void
+            |      });
+            |      `test//`.describeShape = (@stay fn describeShape(s__0 /* aka s */: Shape) /* return__4 */: String {
+            |          if (!is(s__0, Circle)) {
+            |            if (is(s__0, Square)) {}
+            |          };
+            |          return__4 = void
+            |      })
+            |
+            |      ```
+            |  },
+            |  errors: [
+            |    "Cannot assign to String from Void!",
+            |    "Expected subtype of String, but got Void!",
+            |    "Void expressions cannot be used as values!",
+            |    "Cannot assign to String from Void!",
+            |    "Expected subtype of String, but got Void!",
+            |    "Void expressions cannot be used as values!",
+            |  ]
+            |}
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
+
+    @Test
     fun assignmentsToTypedReturnAreChecked() = assertModuleAtStage(
         stage = Stage.GenerateCode,
         input = """

--- a/fundamentals/src/commonMain/kotlin/lang/temper/value/NullaryNeverFn.kt
+++ b/fundamentals/src/commonMain/kotlin/lang/temper/value/NullaryNeverFn.kt
@@ -45,6 +45,25 @@ object BubbleFn : NullaryNeverFn {
 }
 
 /**
+ * Specifically so far, this is inserted for missing else clauses. This should
+ * stay panic if the else is found unreachable based on type information.
+ * Otherwise, it should become void. The value formals are the value being
+ * checked and the static type it needs to have for the check to be exhaustive.
+ */
+object VoidishPanicFn : NullaryNeverFn {
+    override val name = "voidishPanic"
+
+    override val callMayFailPerSe: Boolean get() = false
+
+    override fun invoke(args: ActualValues, cb: InterpreterCallback, interpMode: InterpMode) =
+        throw Panic()
+
+    override val sigs = nullaryNeverReturnsSigs(
+        requiredInputTypes = listOf(WKT.anyValueType2, WKT.typeType2),
+    ) { it }
+}
+
+/**
  * Panics immediately.
  *
  *  * <!-- snippet: builtin/panic -->
@@ -164,6 +183,7 @@ object ErrorFn : NullaryNeverFn, TokenSerializable {
 }
 
 private fun NamedBuiltinFun.nullaryNeverReturnsSigs(
+    requiredInputTypes: List<Type2> = listOf(),
     makeReturnType: (Type2) -> Type2,
 ): List<Signature2> {
     val nameKey = "${name}T"
@@ -187,13 +207,13 @@ private fun NamedBuiltinFun.nullaryNeverReturnsSigs(
     return listOf(
         Signature2(
             returnType2 = neverVoidReturnType,
-            requiredInputTypes = listOf(),
+            requiredInputTypes = requiredInputTypes,
             hasThisFormal = false,
             typeFormals = listOf(),
         ),
         Signature2(
             returnType2 = neverTReturnType,
-            requiredInputTypes = listOf(),
+            requiredInputTypes = requiredInputTypes,
             hasThisFormal = false,
             typeFormals = listOf(typeFormal),
         ),

--- a/fundamentals/src/commonMain/kotlin/lang/temper/value/SimplifyControlFlow.kt
+++ b/fundamentals/src/commonMain/kotlin/lang/temper/value/SimplifyControlFlow.kt
@@ -179,8 +179,21 @@ fun simplifyControlFlow(
 ): StructuredFlow {
     val nameMaker = block.document.nameMaker
 
-    fun truthiness(ref: BlockChildReference) =
-        block.dereference(ref)?.valueContained(TBoolean)
+    fun truthiness(ref: BlockChildReference): Boolean? {
+        // Ideally, we just have a simple boolean value.
+        val tree = (block.dereference(ref) ?: return null).target
+        tree.valueContained(TBoolean)?.let { simpleAnswer -> return@truthiness simpleAnswer }
+        // Not completely simple, but check for simple negation of a boolean value.
+        tree is CallTree && tree.size == 2 || return null
+        val value = tree.child(1).valueContained(TBoolean) ?: return null
+        // Single boolean operand, so dig more at the function.
+        val fn = tree.child(0).functionContained ?: return null
+        fn is CoverFunction && fn.covered.all { covered ->
+            covered is NamedBuiltinFun && covered.builtinOperatorId == BuiltinOperatorId.BooleanNegation
+        } || return null
+        // Yep, got it.
+        return !value
+    }
 
     val loopDepth = DepthCounter()
 

--- a/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
@@ -218,22 +218,6 @@ internal object IfTransform : ControlFlowTransform("if") {
                     }
                 }
 
-                // `if` chains that don't end in an `else` should be typed as Void.
-                // See LoopTransform comments on typing as for the problems with control-flow
-                // constructs that start with a condition and which don't reliably follow it
-                // with a typeable tree.
-                if (controlFlow != null && !hasFinalElse) {
-                    controlFlow = ControlFlow.StmtBlock(
-                        controlFlow.pos,
-                        listOf(
-                            controlFlow,
-                            ControlFlow.Stmt(
-                                macroCursor.referenceToVoid(controlFlow.pos.rightEdge),
-                            ),
-                        ),
-                    )
-                }
-
                 controlFlow?.let { ControlFlowSubflow(it) }
             }
         }

--- a/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
@@ -197,11 +197,13 @@ internal object IfTransform : ControlFlowTransform("if") {
                     if (hasFinalElse) {
                         null
                     } else {
+                        // Using `rightEdge` here improves diagnostic positions such as in UseBeforeInit.
+                        val endPos = wholePos.rightEdge
                         when (val nameType = anyExhaustiveSealedType(branches)) {
-                            null -> macroCursor.referenceToVoid(wholePos)
+                            null -> macroCursor.referenceToVoid(endPos)
                             else -> {
                                 val (checkedName, expectedType) = nameType
-                                val panicCall = macroCursor.macroEnvironment.document.treeFarm.grow(wholePos) {
+                                val panicCall = macroCursor.macroEnvironment.document.treeFarm.grow(endPos) {
                                     Block {
                                         Call {
                                             V(BuiltinFuns.vVoidishPanic)

--- a/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
@@ -198,11 +198,10 @@ internal object IfTransform : ControlFlowTransform("if") {
                         null
                     } else {
                         when (val nameType = anyExhaustiveSealedType(branches)) {
-                            null -> macroCursor.referenceToVoid(macroCursor.macroEnvironment.pos.rightEdge)
+                            null -> macroCursor.referenceToVoid(wholePos)
                             else -> {
                                 val (checkedName, expectedType) = nameType
-                                val pos = macroCursor.macroEnvironment.pos
-                                val panicCall = macroCursor.macroEnvironment.document.treeFarm.grow(pos) {
+                                val panicCall = macroCursor.macroEnvironment.document.treeFarm.grow(wholePos) {
                                     Block {
                                         Call {
                                             V(BuiltinFuns.vVoidishPanic)

--- a/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/IfTransform.kt
@@ -1,21 +1,30 @@
 package lang.temper.interp
 
+import lang.temper.builtin.BuiltinFuns
 import lang.temper.env.InterpMode
 import lang.temper.log.spanningPosition
+import lang.temper.name.TemperName
+import lang.temper.type.TypeDefinition
+import lang.temper.type.TypeShape
+import lang.temper.type2.MkType2
 import lang.temper.type2.Signature2
 import lang.temper.value.ActualValues
+import lang.temper.value.CallTree
 import lang.temper.value.ControlFlow
 import lang.temper.value.Fail
 import lang.temper.value.MacroEnvironment
 import lang.temper.value.NamedBuiltinFun
 import lang.temper.value.NotYet
 import lang.temper.value.PartialResult
+import lang.temper.value.ReifiedType
 import lang.temper.value.Result
 import lang.temper.value.SpecialFunction
 import lang.temper.value.TEdge
 import lang.temper.value.Value
 import lang.temper.value.elseIfSymbol
 import lang.temper.value.elseSymbol
+import lang.temper.value.nameContained
+import lang.temper.value.valueContained
 import lang.temper.value.void
 
 /**
@@ -188,11 +197,23 @@ internal object IfTransform : ControlFlowTransform("if") {
                     if (hasFinalElse) {
                         null
                     } else {
-                        // Having a `void` here makes sure that static checks like UseBeforeInit
-                        // get a diagnostic position for error logging.
-                        ControlFlow.Stmt(
-                            macroCursor.referenceToVoid(macroCursor.macroEnvironment.pos.rightEdge),
-                        )
+                        when (val nameType = anyExhaustiveSealedType(branches)) {
+                            null -> macroCursor.referenceToVoid(macroCursor.macroEnvironment.pos.rightEdge)
+                            else -> {
+                                val (checkedName, expectedType) = nameType
+                                val pos = macroCursor.macroEnvironment.pos
+                                val panicCall = macroCursor.macroEnvironment.document.treeFarm.grow(pos) {
+                                    Block {
+                                        Call {
+                                            V(BuiltinFuns.vVoidishPanic)
+                                            Rn(checkedName)
+                                            V(Value(expectedType))
+                                        }
+                                    }
+                                }.edge(0)
+                                macroCursor.referenceTo(panicCall)
+                            }
+                        }.let { ControlFlow.Stmt(it) }
                     }
                 while (branchIndex != 0) {
                     branchIndex -= 1
@@ -222,4 +243,45 @@ internal object IfTransform : ControlFlowTransform("if") {
             }
         }
     }
+}
+
+/**
+ * Check for simple sealed exhaustiveness. This requires that a single name be
+ * checked against each sealed subtype of some sealed supertype. If so, default
+ * to voidish panic instead of void, which allows for type inference without an
+ * else.
+ *
+ * Rely on checks elsewhere to validate and replace with either void or standard
+ * panic.
+ *
+ * TODO Fancy flowtyping check for exhaustiveness.
+ */
+private fun anyExhaustiveSealedType(branches: MutableList<Pair<TEdge?, TEdge>>): Pair<TemperName, ReifiedType>? {
+    val allFoundSealedSubs = mutableMapOf<TypeShape, MutableSet<TypeDefinition>>()
+    var checkedName: TemperName? = null
+    branches@ for (branch in branches) {
+        val condition = branch.first?.target as? CallTree ?: continue@branches
+        condition.childOrNull(0)?.valueContained?.stateVector == BuiltinFuns.isFn || continue@branches
+        val nextCheckedName = condition.childOrNull(1)?.nameContained ?: continue@branches
+        when (checkedName) {
+            null -> checkedName = nextCheckedName
+            else if checkedName != nextCheckedName -> break@branches
+            else -> {}
+        }
+        val subtype = condition.childOrNull(2)?.valueContained?.stateVector as? ReifiedType ?: continue@branches
+        val subdef = subtype.type2.definition
+        supertypes@ for (supertype in subdef.superTypes) {
+            val supershape = supertype.definition as? TypeShape
+            val sealedSubs = supershape?.sealedSubTypes ?: continue@supertypes
+            if (subdef in sealedSubs) {
+                val foundSealedSubs = allFoundSealedSubs.getOrPut(supershape) { mutableSetOf() }
+                foundSealedSubs.add(subdef)
+                if (foundSealedSubs.size == sealedSubs.size) {
+                    // For purposes of later type verification, we don't need any type actual bindings.
+                    return checkedName to ReifiedType(MkType2(supershape).get())
+                }
+            }
+        }
+    }
+    return null
 }

--- a/log/src/commonMain/kotlin/lang/temper/log/Debug.kt
+++ b/log/src/commonMain/kotlin/lang/temper/log/Debug.kt
@@ -67,7 +67,7 @@ object Debug : LogConfigurations("*", null, listOf("frontend", "backend", "docge
             object ConvertObjectSyntax : LogConfigurations("frontend.defineStage.convertObjectSyntax", "frontend.defineStage", listOf())
             object After : LogConfigurations("frontend.defineStage.after", "frontend.defineStage", listOf())
         }
-        object TypeStage : LogConfigurations("frontend.typeStage", "frontend", listOf("frontend.typeStage.before", "frontend.typeStage.beforeInterpretation", "frontend.typeStage.afterInterpretation", "frontend.typeStage.magicSecurityDust", "frontend.typeStage.afterSprinkle", "frontend.typeStage.weaver", "frontend.typeStage.afterWeave", "frontend.typeStage.simplifyFlow", "frontend.typeStage.afterSimplifyFlow", "frontend.typeStage.makeResultsExplicit", "frontend.typeStage.afterExplicitResults", "frontend.typeStage.type", "frontend.typeStage.afterTyper", "frontend.typeStage.useBeforeInit", "frontend.typeStage.afterUseBeforeInit", "frontend.typeStage.reorderArgs", "frontend.typeStage.afterReorderArgs", "frontend.typeStage.simplifyFlow2", "frontend.typeStage.afterSimplifyFlow2", "frontend.typeStage.cleanupTemporaries", "frontend.typeStage.afterCleanupTemporaries", "frontend.typeStage.simplifyFlow3", "frontend.typeStage.afterSimplifyFlow3", "frontend.typeStage.repairUnrealizedGoals", "frontend.typeStage.afterRepairUnrealizedGoals", "frontend.typeStage.after")) {
+        object TypeStage : LogConfigurations("frontend.typeStage", "frontend", listOf("frontend.typeStage.before", "frontend.typeStage.beforeInterpretation", "frontend.typeStage.afterInterpretation", "frontend.typeStage.magicSecurityDust", "frontend.typeStage.afterSprinkle", "frontend.typeStage.weaver", "frontend.typeStage.afterWeave", "frontend.typeStage.simplifyFlow", "frontend.typeStage.afterSimplifyFlow", "frontend.typeStage.makeResultsExplicit", "frontend.typeStage.afterExplicitResults", "frontend.typeStage.type", "frontend.typeStage.afterTyper", "frontend.typeStage.replaceVoidishPanics", "frontend.typeStage.afterReplaceVoidishPanics", "frontend.typeStage.useBeforeInit", "frontend.typeStage.afterUseBeforeInit", "frontend.typeStage.reorderArgs", "frontend.typeStage.afterReorderArgs", "frontend.typeStage.simplifyFlow2", "frontend.typeStage.afterSimplifyFlow2", "frontend.typeStage.cleanupTemporaries", "frontend.typeStage.afterCleanupTemporaries", "frontend.typeStage.simplifyFlow3", "frontend.typeStage.afterSimplifyFlow3", "frontend.typeStage.repairUnrealizedGoals", "frontend.typeStage.afterRepairUnrealizedGoals", "frontend.typeStage.after")) {
             object Before : LogConfigurations("frontend.typeStage.before", "frontend.typeStage", listOf())
             object BeforeInterpretation : LogConfigurations("frontend.typeStage.beforeInterpretation", "frontend.typeStage", listOf())
             object AfterInterpretation : LogConfigurations("frontend.typeStage.afterInterpretation", "frontend.typeStage", listOf())
@@ -81,6 +81,8 @@ object Debug : LogConfigurations("*", null, listOf("frontend", "backend", "docge
             object AfterExplicitResults : LogConfigurations("frontend.typeStage.afterExplicitResults", "frontend.typeStage", listOf())
             object Type : LogConfigurations("frontend.typeStage.type", "frontend.typeStage", listOf())
             object AfterTyper : LogConfigurations("frontend.typeStage.afterTyper", "frontend.typeStage", listOf())
+            object ReplaceVoidishPanics : LogConfigurations("frontend.typeStage.replaceVoidishPanics", "frontend.typeStage", listOf())
+            object AfterReplaceVoidishPanics : LogConfigurations("frontend.typeStage.afterReplaceVoidishPanics", "frontend.typeStage", listOf())
             object UseBeforeInit : LogConfigurations("frontend.typeStage.useBeforeInit", "frontend.typeStage", listOf())
             object AfterUseBeforeInit : LogConfigurations("frontend.typeStage.afterUseBeforeInit", "frontend.typeStage", listOf())
             object ReorderArgs : LogConfigurations("frontend.typeStage.reorderArgs", "frontend.typeStage", listOf())
@@ -180,6 +182,8 @@ val logConfigurationsByName: Map<String, LogConfigurations> = mapOf(
     "frontend.typeStage.afterExplicitResults" to Debug.Frontend.TypeStage.AfterExplicitResults,
     "frontend.typeStage.type" to Debug.Frontend.TypeStage.Type,
     "frontend.typeStage.afterTyper" to Debug.Frontend.TypeStage.AfterTyper,
+    "frontend.typeStage.replaceVoidishPanics" to Debug.Frontend.TypeStage.ReplaceVoidishPanics,
+    "frontend.typeStage.afterReplaceVoidishPanics" to Debug.Frontend.TypeStage.AfterReplaceVoidishPanics,
     "frontend.typeStage.useBeforeInit" to Debug.Frontend.TypeStage.UseBeforeInit,
     "frontend.typeStage.afterUseBeforeInit" to Debug.Frontend.TypeStage.AfterUseBeforeInit,
     "frontend.typeStage.reorderArgs" to Debug.Frontend.TypeStage.ReorderArgs,

--- a/log/src/commonMain/kotlin/lang/temper/log/logger-names.json
+++ b/log/src/commonMain/kotlin/lang/temper/log/logger-names.json
@@ -68,6 +68,8 @@
     "frontend.typeStage.afterExplicitResults",
     "frontend.typeStage.type",
     "frontend.typeStage.afterTyper",
+    "frontend.typeStage.replaceVoidishPanics",
+    "frontend.typeStage.afterReplaceVoidishPanics",
     "frontend.typeStage.useBeforeInit",
     "frontend.typeStage.afterUseBeforeInit",
     "frontend.typeStage.reorderArgs",


### PR DESCRIPTION
- Fix #427
- Improved version of #439 that knows if the static type is narrow enough
- If there's a simple chain checking every variant of a sealed type, and if the variable is typed to that sealed type, insert panic instead void
- Don't insert post-chain void on missing `else` because that's harder now, but that affects positions and also makes semicolon more vital
- Also make `truthiness` smarter for simplify control flow, but not really taking advantage of that here