### PR TITLE
Make common cppv ushr build on cpp03

### DIFF
--- a/be-cppv/src/commonMain/resources/lang/temper/be/cppv/temper-core/int.hpp
+++ b/be-cppv/src/commonMain/resources/lang/temper/be/cppv/temper-core/int.hpp
@@ -7,7 +7,6 @@
 #include <limits>
 #include <stdint.h>
 #include <stdlib.h>
-#include <type_traits>
 #include "expected.hpp"
 #include "shared.hpp"
 
@@ -101,8 +100,8 @@ T neg(T i) {
 
 template<typename T>
 T ushr(T i, int32_t j) {
-  constexpr int shift_size_mask = (sizeof(T) * CHAR_BIT) - 1;
-  return (T) (((typename std::make_unsigned<T>::type) i) >> (j & shift_size_mask));
+  int shift_size_mask = (sizeof(T) * CHAR_BIT) - 1;
+  return (T) (to_unsigned(i) >> (j & shift_size_mask));
 }
 
 Expected<int32_t> to_int32(int64_t i) {


### PR DESCRIPTION
- Not sure ushr actually gets tested so far, but this at least builds under c++03 for funtests that we let run
- Future PRs need to figure out how much of new be-cpp is compatible with c++03 since we need to retire be-cppv
  - Worst case, any c++03 support is mostly independent and somewhat incompatible with be-cpp libraries
- We also still need to see if any ideas of be-cppv should be folded into be-cpp
- This PR is just a minimal change to get c++03 working again