### PR TITLE
Avoid saying `temper` in temper-built c++

### DIFF
--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
@@ -41,7 +41,7 @@ import lang.temper.name.LanguageLabel
  * ## Initialization
  *
  * All module-level variable initializations and init blocks are deferred to an explicit
- * `temper_init_<module>()` function, called from `main()`, to avoid the Static
+ * `global_init_<module>()` function, called from `main()`, to avoid the Static
  * Initialization Order Fiasco (SIOF). Cross-module dependency init functions are
  * called first within each module's init function.
  *

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
@@ -123,7 +123,7 @@ class CppBackend private constructor(
             allTestInfos.addAll(translator.testInfos)
             translator.moduleInitFuncName?.let { name ->
                 val libNs = safeCppNamespace(cppNames.library(cppLibraryName).text)
-                allInitFuncs.add("temper::${libNs}::$name")
+                allInitFuncs.add("$libNs::$name")
                 // Track include path for this module's header so main.cpp can see all init decls
                 val loc = mod.codeLocation.codeLocation
                 allInitIncludes.add(translator.cpp.includePathForModule(loc))
@@ -140,7 +140,7 @@ class CppBackend private constructor(
         )
 
         // Compute the C++ namespace for the std library's Test type
-        val testNs = "temper::${safeCppNamespace(cppNames.library("std").text)}"
+        val testNs = safeCppNamespace(cppNames.library("std").text)
 
         val mainContent = generateMainCpp(
             initIncludes = allInitIncludes.sorted(),

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -3076,7 +3076,7 @@ class CppTranslator(
     }
 
     /**
-     * Gather the fully-qualified `temper_init_*` calls for every imported dependency module,
+     * Gather the fully-qualified `global_init_*` calls for every imported dependency module,
      * adding each dependency's header to [includes] as a side effect.
      */
     private fun gatherDependencyInitCalls(): MutableSet<String> {
@@ -3090,7 +3090,7 @@ class CppTranslator(
                 else -> depRelPath.segments.last().baseName
             }
             val sanitizedDep = depBaseName.replace(Regex("[^a-zA-Z0-9_]"), "_")
-            depInitCalls.add("$libNs::temper_init_$sanitizedDep")
+            depInitCalls.add("$libNs::global_init_$sanitizedDep")
             // Add include for the dependency module's header so its init decl is visible
             includes.add(cpp.includePathForModule(depModName))
         }
@@ -3098,7 +3098,7 @@ class CppTranslator(
     }
 
     /**
-     * Emit the deferred `temper_init_<module>()` function (header decl + impl def) that guards
+     * Emit the deferred `global_init_<module>()` function (header decl + impl def) that guards
      * against double init, calls dependency module inits, then runs the deferred variable
      * initializations. Sets [moduleInitFuncName] as a side effect.
      */
@@ -3110,7 +3110,7 @@ class CppTranslator(
     ) {
         // Generate module init function with dependency init calls
         // and deferred variable initializations.
-        val initFuncName = cpp.singleName(CppName("temper_init_$sanitizedModuleName"))
+        val initFuncName = cpp.singleName(CppName("global_init_$sanitizedModuleName"))
         moduleInitFuncName = initFuncName.id.text
 
         val bodyStmts = mutableListOf<Cpp.Stmt>()

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -3070,7 +3070,7 @@ class CppTranslator(
         }
         val qualifiedName = when (libNs) {
             null -> "temper::${cppName.id.text}"
-            else -> "temper::${libNs}::${cppName.id.text}"
+            else -> "$libNs::${cppName.id.text}"
         }
         testInfos.add(qualifiedName to topLevel.rawName)
     }
@@ -3090,7 +3090,7 @@ class CppTranslator(
                 else -> depRelPath.segments.last().baseName
             }
             val sanitizedDep = depBaseName.replace(Regex("[^a-zA-Z0-9_]"), "_")
-            depInitCalls.add("temper::${libNs}::temper_init_$sanitizedDep")
+            depInitCalls.add("$libNs::temper_init_$sanitizedDep")
             // Add include for the dependency module's header so its init decl is visible
             includes.add(cpp.includePathForModule(depModName))
         }
@@ -3202,8 +3202,7 @@ class CppTranslator(
                 null -> body
                 else -> listOf(cpp.namespace(cpp.libraryName(cppLibraryName), body))
             }
-            val finalNamespace = cpp.namespace(cpp.singleName(CppName("temper")), innerNamespace)
-            return@pos listOf(finalNamespace)
+            return@pos innerNamespace
         }
 
         val relPath = mod.codeLocation.codeLocation.relativePath()

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -26,26 +26,24 @@ class CppBackendTest {
             """,
             cpp = """
                 |#include <my-test-library/something.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    static std::shared_ptr<temper::core::Console::Type> console_0;
-                |    static int32_t x;
-                |    void greet(std::string name) {
-                |      temper::core::Console::log(console_0, "Hi:");
-                |      temper::core::Console::log(console_0, name);
+                |namespace my_test_library {
+                |  static std::shared_ptr<temper::core::Console::Type> console_0;
+                |  static int32_t x;
+                |  void greet(std::string name) {
+                |    temper::core::Console::log(console_0, "Hi:");
+                |    temper::core::Console::log(console_0, name);
+                |    return;
+                |  }
+                |  void temper_init_something() {
+                |    static bool initialized = false;
+                |    if(initialized) {
                 |      return;
                 |    }
-                |    void temper_init_something() {
-                |      static bool initialized = false;
-                |      if(initialized) {
-                |        return;
-                |      }
-                |      initialized = true;
-                |      console_0 = temper::core::Console::get_console();
-                |      greet("world");
-                |      x = 3;
-                |      greet(temper::core::cat("world ", temper::core::Int::toString(3)));
-                |    }
+                |    initialized = true;
+                |    console_0 = temper::core::Console::get_console();
+                |    greet("world");
+                |    x = 3;
+                |    greet(temper::core::cat("world ", temper::core::Int::toString(3)));
                 |  }
                 |}
                 |
@@ -53,11 +51,9 @@ class CppBackendTest {
             hpp = """
                 |#pragma once
                 |#include <temper-core/core.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    void greet(std::string);
-                |    void temper_init_something();
-                |  }
+                |namespace my_test_library {
+                |  void greet(std::string);
+                |  void temper_init_something();
                 |}
                 |
             """,
@@ -75,9 +71,9 @@ class CppBackendTest {
             """,
             cppContains = listOf(
                 """
-                    |    int32_t day(std::shared_ptr<temper_std::Date> const & date) {
-                    |      return temper::core::Date::getDay(date);
-                    |    }
+                    |  int32_t day(std::shared_ptr<temper_std::Date> const & date) {
+                    |    return temper::core::Date::getDay(date);
+                    |  }
                 """.trimMargin(),
             ),
         )
@@ -93,18 +89,16 @@ class CppBackendTest {
             """,
             cpp = """
                 |#include <my-test-library/something.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    int32_t add(int32_t a, int32_t b) {
-                |      return temper::core::Int::add(a, b);
+                |namespace my_test_library {
+                |  int32_t add(int32_t a, int32_t b) {
+                |    return temper::core::Int::add(a, b);
+                |  }
+                |  void temper_init_something() {
+                |    static bool initialized = false;
+                |    if(initialized) {
+                |      return;
                 |    }
-                |    void temper_init_something() {
-                |      static bool initialized = false;
-                |      if(initialized) {
-                |        return;
-                |      }
-                |      initialized = true;
-                |    }
+                |    initialized = true;
                 |  }
                 |}
                 |
@@ -112,11 +106,9 @@ class CppBackendTest {
             hpp = """
                 |#pragma once
                 |#include <temper-core/core.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    int32_t add(int32_t, int32_t);
-                |    void temper_init_something();
-                |  }
+                |namespace my_test_library {
+                |  int32_t add(int32_t, int32_t);
+                |  void temper_init_something();
                 |}
                 |
             """,
@@ -131,17 +123,15 @@ class CppBackendTest {
             """,
             cpp = """
                 |#include <my-test-library/something.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    int32_t x;
-                |    void temper_init_something() {
-                |      static bool initialized = false;
-                |      if(initialized) {
-                |        return;
-                |      }
-                |      initialized = true;
-                |      x = 42;
+                |namespace my_test_library {
+                |  int32_t x;
+                |  void temper_init_something() {
+                |    static bool initialized = false;
+                |    if(initialized) {
+                |      return;
                 |    }
+                |    initialized = true;
+                |    x = 42;
                 |  }
                 |}
                 |
@@ -149,11 +139,9 @@ class CppBackendTest {
             hpp = """
                 |#pragma once
                 |#include <temper-core/core.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    extern int32_t x;
-                |    void temper_init_something();
-                |  }
+                |namespace my_test_library {
+                |  extern int32_t x;
+                |  void temper_init_something();
                 |}
                 |
             """,
@@ -170,18 +158,16 @@ class CppBackendTest {
             """,
             cpp = """
                 |#include <my-test-library/something.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    bool isPositive(int32_t x) {
-                |      return x> 0;
+                |namespace my_test_library {
+                |  bool isPositive(int32_t x) {
+                |    return x> 0;
+                |  }
+                |  void temper_init_something() {
+                |    static bool initialized = false;
+                |    if(initialized) {
+                |      return;
                 |    }
-                |    void temper_init_something() {
-                |      static bool initialized = false;
-                |      if(initialized) {
-                |        return;
-                |      }
-                |      initialized = true;
-                |    }
+                |    initialized = true;
                 |  }
                 |}
                 |
@@ -189,11 +175,9 @@ class CppBackendTest {
             hpp = """
                 |#pragma once
                 |#include <temper-core/core.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    bool isPositive(int32_t);
-                |    void temper_init_something();
-                |  }
+                |namespace my_test_library {
+                |  bool isPositive(int32_t);
+                |  void temper_init_something();
                 |}
                 |
             """,
@@ -210,18 +194,16 @@ class CppBackendTest {
             """,
             cpp = """
                 |#include <my-test-library/something.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    int32_t multiply(int32_t a, int32_t b) {
-                |      return temper::core::Int::mul(a, b);
+                |namespace my_test_library {
+                |  int32_t multiply(int32_t a, int32_t b) {
+                |    return temper::core::Int::mul(a, b);
+                |  }
+                |  void temper_init_something() {
+                |    static bool initialized = false;
+                |    if(initialized) {
+                |      return;
                 |    }
-                |    void temper_init_something() {
-                |      static bool initialized = false;
-                |      if(initialized) {
-                |        return;
-                |      }
-                |      initialized = true;
-                |    }
+                |    initialized = true;
                 |  }
                 |}
                 |
@@ -229,11 +211,9 @@ class CppBackendTest {
             hpp = """
                 |#pragma once
                 |#include <temper-core/core.hpp>
-                |namespace temper {
-                |  namespace my_test_library {
-                |    int32_t multiply(int32_t, int32_t);
-                |    void temper_init_something();
-                |  }
+                |namespace my_test_library {
+                |  int32_t multiply(int32_t, int32_t);
+                |  void temper_init_something();
                 |}
                 |
             """,
@@ -567,10 +547,10 @@ class CppBackendTest {
             """,
             cppContains = listOf(
                 """
-                    |    int32_t Apple::twiceThing(int32_t i_8)const {
-                    |      auto this_1 = temper::core::borrow_this(this);
-                    |      return temper::core::Int::mul(2, this_1->thing(i_8));
-                    |    }
+                    |  int32_t Apple::twiceThing(int32_t i_8)const {
+                    |    auto this_1 = temper::core::borrow_this(this);
+                    |    return temper::core::Int::mul(2, this_1->thing(i_8));
+                    |  }
                 """.trimMargin(),
             ),
         )

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -34,7 +34,7 @@ class CppBackendTest {
                 |    temper::core::Console::log(console_0, name);
                 |    return;
                 |  }
-                |  void temper_init_something() {
+                |  void global_init_something() {
                 |    static bool initialized = false;
                 |    if(initialized) {
                 |      return;
@@ -53,7 +53,7 @@ class CppBackendTest {
                 |#include <temper-core/core.hpp>
                 |namespace my_test_library {
                 |  void greet(std::string);
-                |  void temper_init_something();
+                |  void global_init_something();
                 |}
                 |
             """,
@@ -93,7 +93,7 @@ class CppBackendTest {
                 |  int32_t add(int32_t a, int32_t b) {
                 |    return temper::core::Int::add(a, b);
                 |  }
-                |  void temper_init_something() {
+                |  void global_init_something() {
                 |    static bool initialized = false;
                 |    if(initialized) {
                 |      return;
@@ -108,7 +108,7 @@ class CppBackendTest {
                 |#include <temper-core/core.hpp>
                 |namespace my_test_library {
                 |  int32_t add(int32_t, int32_t);
-                |  void temper_init_something();
+                |  void global_init_something();
                 |}
                 |
             """,
@@ -125,7 +125,7 @@ class CppBackendTest {
                 |#include <my-test-library/something.hpp>
                 |namespace my_test_library {
                 |  int32_t x;
-                |  void temper_init_something() {
+                |  void global_init_something() {
                 |    static bool initialized = false;
                 |    if(initialized) {
                 |      return;
@@ -141,7 +141,7 @@ class CppBackendTest {
                 |#include <temper-core/core.hpp>
                 |namespace my_test_library {
                 |  extern int32_t x;
-                |  void temper_init_something();
+                |  void global_init_something();
                 |}
                 |
             """,
@@ -162,7 +162,7 @@ class CppBackendTest {
                 |  bool isPositive(int32_t x) {
                 |    return x> 0;
                 |  }
-                |  void temper_init_something() {
+                |  void global_init_something() {
                 |    static bool initialized = false;
                 |    if(initialized) {
                 |      return;
@@ -177,7 +177,7 @@ class CppBackendTest {
                 |#include <temper-core/core.hpp>
                 |namespace my_test_library {
                 |  bool isPositive(int32_t);
-                |  void temper_init_something();
+                |  void global_init_something();
                 |}
                 |
             """,
@@ -198,7 +198,7 @@ class CppBackendTest {
                 |  int32_t multiply(int32_t a, int32_t b) {
                 |    return temper::core::Int::mul(a, b);
                 |  }
-                |  void temper_init_something() {
+                |  void global_init_something() {
                 |    static bool initialized = false;
                 |    if(initialized) {
                 |      return;
@@ -213,7 +213,7 @@ class CppBackendTest {
                 |#include <temper-core/core.hpp>
                 |namespace my_test_library {
                 |  int32_t multiply(int32_t, int32_t);
-                |  void temper_init_something();
+                |  void global_init_something();
                 |}
                 |
             """,


### PR DESCRIPTION
- Libraries built by temper should just be libraries in whatever target language
- Stop putting `temper::` namespacing around user libraries
  - If we don't yet have c++ namespace config in config.temper.md, we can add that in the future
- Also say `global_init_...` instead of `temper_init_...` to init user libraries