### PR TITLE
Fix be-rust for call instead of bind

### DIFF
--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustSupportNetwork.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustSupportNetwork.kt
@@ -24,9 +24,7 @@ import lang.temper.name.OutName
 import lang.temper.name.ParsedName
 import lang.temper.name.name
 import lang.temper.type.WellKnownTypes
-import lang.temper.type2.DefinedNonNullType
 import lang.temper.type2.DefinedType
-import lang.temper.type2.MkType2
 import lang.temper.type2.Signature2
 import lang.temper.type2.Type2
 import lang.temper.type2.withType
@@ -678,19 +676,8 @@ private object CmpGeneric : MethodCall(
         returnType: Type2,
         translator: RustTranslator,
     ): Rust.Expr {
-        // Work around core.type StringIndexOption.compareTo() typing if needed.
-        val self = arguments.getOrNull(0)
-        val effectiveArgs = when ((self?.type as? DefinedNonNullType)?.definition) {
-            WellKnownTypes.stringIndexTypeDefinition -> buildList {
-                // Left should be an option, not a string index, but we don't get the function type that way.
-                val optionType = MkType2(WellKnownTypes.stringIndexOptionTypeDefinition).get()
-                add(TypedArg((self.expr as Rust.Expr).wrapSome(), optionType))
-                addAll(arguments.subListToEnd(1))
-            }
-            else -> arguments
-        }
-        // And cast result as i32 for be-rust int expectations.
-        return super.inlineToTree(pos, effectiveArgs, returnType, translator).infix(RustOperator.As, "i32".toId(pos))
+        // Cast result as i32 for temper Int type expectations.
+        return super.inlineToTree(pos, arguments, returnType, translator).infix(RustOperator.As, "i32".toId(pos))
     }
 }
 

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -96,14 +96,11 @@ class RustBackendTest {
             |            pub (crate) fn init() -> temper_core::Result<()> {
             |                static INIT_ONCE: std::sync::OnceLock<temper_core::Result<()>> = std::sync::OnceLock::new();
             |                INIT_ONCE.get_or_init(| |{
+            |                        let stringifyValue__0: std::sync::Arc<dyn Fn (i32) -> std::sync::Arc<String> + std::marker::Send + std::marker::Sync> = std::sync::Arc::new(crate::bar::stringify.clone());
             |                        println!("{}", "Foo");
-            |                        STRINGIFY_VALUE_HERE.set(std::sync::Arc::new(stringifyHere__0.clone())).unwrap_or_else(| _ | panic!());
+            |                        let stringifyValueHere__0: std::sync::Arc<dyn Fn (i32) -> std::sync::Arc<String> + std::marker::Send + std::marker::Sync> = std::sync::Arc::new(stringifyHere__0.clone());
             |                        Ok(())
             |                }).clone()
-            |            }
-            |            static STRINGIFY_VALUE_HERE: std::sync::OnceLock<std::sync::Arc<dyn Fn (i32) -> std::sync::Arc<String> + std::marker::Send + std::marker::Sync>> = std::sync::OnceLock::new();
-            |            fn stringify_value_here() -> std::sync::Arc<dyn Fn (i32) -> std::sync::Arc<String> + std::marker::Send + std::marker::Sync> {
-            |                ( * STRINGIFY_VALUE_HERE.get().unwrap()).clone()
             |            }
             |            fn stringifyHere__0(i__0: i32) -> std::sync::Arc<String> {
             |                return temper_core::int_to_string(i__0, None);
@@ -111,13 +108,13 @@ class RustBackendTest {
             |            pub fn hi(nums__0: impl temper_core::ToListed<i32>) -> std::sync::Arc<String> {
             |                let nums__0 = nums__0.to_listed();
             |                let a__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & crate::bar::stringify.clone());
-            |                let b__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & ( * crate::bar::stringify_value().clone()));
+            |                let b__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & crate::bar::stringify.clone());
             |                let c__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & stringifyHere__0.clone());
-            |                let d__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & ( * stringify_value_here().clone()));
+            |                let d__0: std::sync::Arc<String> = temper_core::listed::join( & ( * nums__0), std::sync::Arc::new("".to_string()), & stringifyHere__0.clone());
             |                return std::sync::Arc::new(format!("{}{}{}{}", a__0, b__0.clone(), c__0.clone(), d__0.clone()));
             |            }
-            |            pub fn make_talk_here(talker__1: crate::bar::Talker) {
-            |                talker__1.talk();
+            |            pub fn make_talk_here(talker__0: crate::bar::Talker) {
+            |                talker__0.talk();
             |            }
             |
             |            ```
@@ -173,8 +170,8 @@ class RustBackendTest {
             |              pub fn stringify(i__1: i32) -> std::sync::Arc<String> {
             |                  return temper_core::int_to_string(i__1, None);
             |              }
-            |              pub fn make_talk(talker__0: Talker) {
-            |                  talker__0.talk();
+            |              pub fn make_talk(talker__1: Talker) {
+            |                  talker__1.talk();
             |              }
             |
             |              ```


### PR DESCRIPTION
- Rely on fixed StringIndexOption compare typing
- Expect more inlining in a backend test