### PR TITLE
frontend: Module.mayRun complicated predictive execution

### DIFF
--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsSupportNetwork.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsSupportNetwork.kt
@@ -962,11 +962,11 @@ private val marshalToJsonObjectSig = lazy {
     val tt = MkType2(t).get()
     // <T>(JsonAdapter<T>, T) -> JsonObject
     Signature2(
-        returnType2 = TType.unpack(jsonObjectExport.value!!).type2,
+        returnType2 = TType.unpack(jsonObjectExport.valueFromStaging!!).type2,
         hasThisFormal = false,
         requiredInputTypes = listOf(
             MkType2(
-                (TType.unpack(jsonAdapterExport.value!!).type2 as DefinedNonNullType)
+                (TType.unpack(jsonAdapterExport.valueFromStaging!!).type2 as DefinedNonNullType)
                     .definition,
             )
                 .actuals(listOf(tt))

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
@@ -36,6 +36,7 @@ import lang.temper.log.dirPath
 import lang.temper.name.BackendId
 import lang.temper.name.DashedIdentifier
 import lang.temper.name.ModuleName
+import lang.temper.stage.Stage
 import lang.temper.value.TBoolean
 import lang.temper.value.toPseudoCode
 
@@ -169,7 +170,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
         }
     }
 
-    advancer.advanceModules()
+    advancer.advanceModules(stopBefore = Stage.Run)
 
     val libraryConfiguration = advancer.getLibraryConfiguration(libraryRoot)!!
     val libraryConfigurationsBundle = LibraryConfigurationsBundle.from(

--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/ConvertCoroutineToControlFlow.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/ConvertCoroutineToControlFlow.kt
@@ -119,7 +119,7 @@ internal fun convertCoroutineToControlFlow(
         return PreTranslated.TreeWrapper(
             document.treeFarm.grow(pos) {
                 Call(pos.leftEdge, New, type = valueResultCtorSig(type)) {
-                    V(pos.leftEdge, valueResultTypeExport.value!!, WellKnownTypes.typeType)
+                    V(pos.leftEdge, valueResultTypeExport.valueFromStaging!!, WellKnownTypes.typeType)
                     when (yielded) {
                         is Either.Left -> Rn(pos, yielded.item, type = hackMapNewStyleToOld(type))
                         is Either.Right -> V(pos, yielded.item, type = hackMapNewStyleToOld(type))

--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLControlFlow.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLControlFlow.kt
@@ -87,7 +87,7 @@ internal fun translateFlow(
     outputName: TemperName?,
     /**
      * If null, do not do a state machine conversion.
-     * If non-null, the type of the generator produced
+     * If non-null, the type of the generator produced.
      */
     stateMachineConversionType: Type2? = null,
 ): PreTranslated {
@@ -211,7 +211,7 @@ private fun translateAltDocGenFn(
 }
 
 /**
- * We need to delayed translation of subtrees until after we've grouped elements of a block
+ * We need to delay translation of subtrees until after we've grouped elements of a block
  * together so that we can group declarations and their initializers.  If we don't suspend them,
  * then we need to treat declarations of functions as assignments of a function value to a local
  * variable instead of as a local function declaration for some period of time.
@@ -332,7 +332,7 @@ internal sealed class PreTranslated : Positioned {
      * This is its own node type because some parts of the translation
      * need to be recombined into a larger translation, like
      * declarations that are initialized before a yield but also
-     * need to be available after a resume.
+     * need to be available after resuming.
      */
     data class ConvertedCoroutine(
         override val pos: Position,
@@ -989,7 +989,8 @@ private class ControlFlowTranslator(
             var toAdd: PreTranslated? = pt
             if (options.nrbStrategy == BubbleBranchStrategy.CatchBubble) {
                 // hs(..., expr) -> expr
-                toAdd = toAdd?.let { unpackHandlerScopeCall(it) } ?: toAdd
+                @Suppress("UNNECESSARY_NOT_NULL_ASSERTION") // To IDE, it's not; to CLI, it is.
+                toAdd = unpackHandlerScopeCall(toAdd!!) ?: toAdd
                 if (toAdd is PreTranslated.TreeWrapper) {
                     val t = toAdd.tree
                     val declParts = (t as? DeclTree)?.parts
@@ -1636,7 +1637,7 @@ private fun removeReferencesAndAssignmentsToVoid(
                 is CallTree -> {
                     if (isVoidLikeAssignment(tree)) {
                         // If it's a void value reference, drop it entirely.
-                        // Otherwise, just substitute the right hand side.
+                        // Otherwise, just substitute the right-hand side.
                         val right = tree.child(2)
                         val rightWrapper = PreTranslated.TreeWrapper(right)
                         rewriteTreeWrapper(rightWrapper, Unit).first
@@ -1950,7 +1951,7 @@ private val doneResultExportStay = lazy {
     (
         TFunction.unpackOrNull(
             ImplicitsModule.module.exports!!.first { it.name.toSymbol().text == doneResultParsedName.nameText }
-                .value,
+                .valueFromStaging,
         ) as? LongLivedUserFunction
         )?.stayLeaf
 }

--- a/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
@@ -53,6 +53,7 @@ import lang.temper.name.ParsedName
 import lang.temper.name.PseudoCodeNameRenumberer
 import lang.temper.name.SourceName
 import lang.temper.name.Symbol
+import lang.temper.stage.Stage
 import lang.temper.type.WellKnownTypes
 import lang.temper.type2.Signature2
 import lang.temper.type2.Type2
@@ -2489,7 +2490,7 @@ class TmpLBackendTest {
         """.trimMargin(),
     )
 
-    // Check that inline support code are not doubly called.
+    // Check that inline support codes are not doubly called.
     // There was a problem in the C# and Lua backends where the connection
     // for static methods like `Date.yearsBetween(a, b)` came out as
     // `TemperCore.Temporal.yearsBetween()(a, b)`.
@@ -4328,7 +4329,7 @@ abstract class TestCompiler(
         )
         partitionSourceFilesIntoModules(snapshot, moduleAdvancer, logSink, console, root = projectRoot)
 
-        moduleAdvancer.advanceModules()
+        moduleAdvancer.advanceModules(stopBefore = Stage.Run)
         return moduleAdvancer.getPartitionedModules()
     }
 

--- a/build-user-docs/src/main/kotlin/lang/temper/docbuild/TemperCodeSnippetExtractor.kt
+++ b/build-user-docs/src/main/kotlin/lang/temper/docbuild/TemperCodeSnippetExtractor.kt
@@ -51,27 +51,25 @@ import org.commonmark.node.Node
 /**
  * Extract and run Temper code blocks.
  *
- * This finds
+ * This finds fenced code blocks:
  *
  *     ```temper
  *     someTemperCode()
  *     ```
  *
- * and rewrites them to
+ * Assuming it worked, that code block is then rewritten to:
  *
  *     ```temper
  *     someTemperCode()
  *     // ✅ void
  *     ```
  *
- * if the code worked, or
+ * If it didn't, we'd have a different trailing comment:
  *
  *     ```temper
  *     someTemperCode()
  *     // ❌ FAIL
  *     ```
- *
- * if it failed.
  *
  * We can express what the snippet should log with `//!outputs` comments.
  *
@@ -84,8 +82,8 @@ import org.commonmark.node.Node
  * If you have an `//!outputs ["array", "of", "lines"]` directive, a newline is implied after each
  * element.
  *
- * If we have no output, and give no hint as to what the code block should produce, this assumes
- * that it produces the value true, so you can assert what code does.
+ * If we have no output and give no hint as to what the code block should produce, this assumes
+ * that it produces the value `true`, so you can assert what code does.
  *
  *     ```temper
  *     1 + 1 == 2
@@ -309,7 +307,7 @@ private class CodeFenceProcessor(
     private val indexOfSnippetInFile: Int,
     private val markdownContent: MarkdownContent,
     /**
-     * In a code fence like
+     * Consider a code fence like the below:
      *
      *     > Markdown quotation
      *     >
@@ -318,8 +316,8 @@ private class CodeFenceProcessor(
      *     > Line 2
      *     > ```
      *
-     * we need to treat `Line 1` and `Line 2` as code content, and treat the newline
-     * as significant but the `>`'s that establish the quotation should not.
+     * We need to treat `Line 1` and `Line 2` as code content, and treat the newline
+     * as significant but the `>`'s that establish the quotation should not be treated as code.
      */
     private val block: FencedCodeBlock,
 ) {
@@ -360,7 +358,7 @@ private class CodeFenceProcessor(
         // Now, find the actual code.
         val allRanges = buildList {
             var start = 0
-            // The first span starts the fence, so get code starting at second.
+            // The first span starts the fence, so get code starting at the second.
             // And presume we've closed all our fences, so end before the last.
             for (index in 1 until block.sourceSpans.size - 1) {
                 val range = markdownContent.range(block.sourceSpans[index])
@@ -450,7 +448,7 @@ private class CodeFenceProcessor(
         val startRange = markdownContent.range(block.sourceSpans.first())
         val endStart = markdownContent.range(block.sourceSpans.last()).first
         val betweenTwoFences = markdownContent.fileContent.slice(
-            // Also skip indent on the end line by backtracking to newline.
+            // Also, skip indent on the end line by backtracking to newline.
             startRange.last + 1..markdownContent.fileContent.lastIndexOf("\n", endStart),
         )
 
@@ -616,15 +614,14 @@ private class CodeFenceProcessor(
                     },
                 ),
             )
-            val module = advancer.createModule(moduleName, runConsole, mayRun = true)
-            @Suppress("AssignedValueIsNeverRead") // Read by moduleCustomizeHook
+            val module = advancer.createModule(moduleName, runConsole)
             moduleToHook = module
             val lexer = makeLexer(formattingLogSink)
             module.deliverContent(lexer, FilePositions.fromSource(from, markdownText))
             module.addEnvironmentBindings(extraBindingsForSnippetCodeModules)
 
             try {
-                advancer.advanceModules()
+                advancer.advanceModules(stopBefore = null)
             } catch (_: Panic) {
                 // Later code will notice that we did not successfully reach Stage.Run
             }

--- a/cli/src/main/kotlin/lang/temper/cli/repl/Repl.kt
+++ b/cli/src/main/kotlin/lang/temper/cli/repl/Repl.kt
@@ -82,7 +82,7 @@ private val dollarToken = OutputToken("$", OutputTokenType.Punctuation)
  * A REPL (Read Eval Print Loop) that allows a user to interactively enter chunks of Temper input.
  *
  * It groups lines until they form a set of complete tokens that have a closing bracket for every
- * open bracket, and processes each such group as a module run through the runtime emulation stage
+ * opener and processes each such group as a module through the runtime emulation stage
  * to produce a result which is logged.
  *
  * Each module implicitly imports all the exports of each previous module, and each module
@@ -346,7 +346,6 @@ internal class Repl(
             chunkIndex.moduleName,
             console,
             continueCondition,
-            mayRun = true,
             sharedLocationContext = sharedLocationContext,
             // For now, infer general verbosity from log level. TODO Thread detailed verbosity info to this point.
             allowDuplicateLogPositions = console.level <= Log.Fine,
@@ -409,10 +408,10 @@ internal class Repl(
             }
             when (module.stageCompleted) {
                 Stage.DisAmbiguate -> {
-                    // Implicitly export top level declarations so that they are visible to later
+                    // Implicitly export top-level declarations so that they are visible to later
                     // command texts
                     module.hookTree { root -> exportTopLevels(module, root) }
-                    // Wrap in a block after we export tops and before we'd reorder them.
+                    // Wrap in a block after we export tops and before we reorder them.
                     module.hookTree { BlockTree.wrap(it) }
                 }
                 Stage.SyntaxMacro -> {
@@ -485,7 +484,7 @@ internal class Repl(
         lastModule = module
         newExports?.let {
             for (export in it) {
-                if (export.value != null) {
+                if (export.valueFromRun != null) {
                     allExports[export.name.baseName] = export
                 }
             }

--- a/cli/src/main/kotlin/lang/temper/cli/repl/SnapshotStore.kt
+++ b/cli/src/main/kotlin/lang/temper/cli/repl/SnapshotStore.kt
@@ -140,7 +140,7 @@ internal class SnapshotStore(
                             out.emit(OutToks.colon)
                             type.renderTo(out)
                         }
-                        val value = export.value
+                        val value = export.valueFromRun ?: export.valueFromStaging
                         if (value != null) {
                             out.emit(OutToks.eq)
                             value.renderTo(

--- a/common/src/commonMain/kotlin/lang/temper/common/Collections.kt
+++ b/common/src/commonMain/kotlin/lang/temper/common/Collections.kt
@@ -328,9 +328,26 @@ fun <K, V> partiallyOrder(
     items: Iterable<V>,
     afterMap: Map<K, Collection<V>>,
     depKeyOf: (V) -> K,
-): List<V> {
+): List<V> = buildList {
+    partiallyOrderTo(items, afterMap, this, depKeyOf)
+}
+
+/**
+ * A list containing [items] and values from [afterMap] such that each, v, appears once after all of
+ * [afterMap]\[k].
+ *
+ * If there is a cycle in [afterMap]'s transitive closure it is broken arbitrarily.
+ *
+ * If there is a v in afterMap\[k] such that k is a dep key for an output element, then v will end
+ * up in the partial order regardless of whether v in items.
+ */
+fun <K, V> partiallyOrderTo(
+    items: Iterable<V>,
+    afterMap: Map<K, Collection<V>>,
+    partialOrder: MutableCollection<V>,
+    depKeyOf: (V) -> K,
+) {
     val ordered = mutableSetOf<V>()
-    val partialOrder = mutableListOf<V>()
     fun addToOrdered(v: V) {
         if (v !in ordered) {
             ordered.add(v) // Arbitrarily breaks cycles.
@@ -347,7 +364,6 @@ fun <K, V> partiallyOrder(
     for (v in items) {
         addToOrdered(v)
     }
-    return partialOrder.toList()
 }
 
 fun intersect(a: IntRange, b: IntRange): IntRange {

--- a/doc-gen/src/main/kotlin/lang/temper/docgen/anticorruption/CompilerImpl.kt
+++ b/doc-gen/src/main/kotlin/lang/temper/docgen/anticorruption/CompilerImpl.kt
@@ -35,6 +35,7 @@ import lang.temper.name.BackendId
 import lang.temper.name.LanguageLabel
 import lang.temper.name.ModuleLocation
 import lang.temper.name.ModuleName
+import lang.temper.stage.Stage
 import lang.temper.supportedBackends.lookupFactory
 import lang.temper.supportedBackends.lookupLanguage
 
@@ -89,7 +90,7 @@ class CompilerImpl(
                         languageConfig = StandaloneLanguageConfig,
                     ),
                 )
-                moduleAdvancer.advanceModules()
+                moduleAdvancer.advanceModules(stopBefore = Stage.Run)
                 if (!module.ok) {
                     console.warn { "${libraryConfiguration.libraryName}.$backendId: module failed" }
                     continue@doBackend

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/FoundAfterModuleStaging.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/FoundAfterModuleStaging.kt
@@ -47,6 +47,14 @@ internal fun findExportsAndDeclaredTypes(
     val declaredTypes = mutableSetOf<TypeShape>()
     var topLevelMetadataDecl: DeclTree? = null
 
+    val exportsBefore by lazy {
+        buildMap {
+            for (export in (exporter.exports ?: listOf())) {
+                this[export.name] = export
+            }
+        }
+    }
+
     // If we have exports, try to relate them to type inferences.
     val declInfoForExports = mutableMapOf<ExportedName, DeclInfo>()
     if (exportedNames.isNotEmpty() && stage >= Stage.Type) {
@@ -101,7 +109,24 @@ internal fun findExportsAndDeclaredTypes(
             val pos = env.declarationSite(exportedName) ?: root.pos.leftEdge
             val (typeInferences, declarationMetadata) =
                 declInfoForExports[exportedName] ?: DeclInfo.empty
-            Export(exporter, exportedName, value, typeInferences, declarationMetadata, pos)
+            val valueFromStaging: Value<*>?
+            val valueFromRun: Value<*>?
+            if (stage == Stage.Run) {
+                valueFromRun = value
+                valueFromStaging = exportsBefore[exportedName]?.valueFromStaging
+            } else {
+                valueFromRun = null
+                valueFromStaging = value
+            }
+            Export(
+                exporter = exporter,
+                name = exportedName,
+                valueFromStaging = valueFromStaging,
+                valueFromRun = valueFromRun,
+                typeInferences = typeInferences,
+                declarationMetadata = declarationMetadata,
+                position = pos,
+            )
         },
         declaredTypes.toList(),
         topLevelMetadataDecl?.let { stayFor(it) },
@@ -121,7 +146,7 @@ fun isStableForMetadata(value: Value<*>): Boolean {
     if (value.stability == ValueStability.Stable) { return true }
 
     // Before we can leave values like Pairs as stable, we need to adjust the
-    // interpreter&|typer to allow us to preserve type parameter info, and
+    // interpreter&|typer to allow us to preserve type parameter info and
     // to allow un-inlining values by reconverting values to constructor
     // expressions during TmpL translation.
     // But for metadata we don't need that, and Pairs are used importantly

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/ModularNameEnvironment.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/ModularNameEnvironment.kt
@@ -18,7 +18,7 @@ import lang.temper.value.NotYet
 /**
  * Resolves names of exported or otherwise externally accessible top-level module constructs.
  *
- * Exports are assumed to be available, as are static properties of declared types, and
+ * Exports are assumed to be available, as are static properties of declared types and
  * methods defined on interface types.
  */
 internal class ModularNameEnvironment(
@@ -51,7 +51,7 @@ internal class ModularNameEnvironment(
         if (name is ExportedName) {
             val export = getExport(name)
             if (export != null) {
-                export.value ?: NotYet
+                export.value(cb.stage) ?: NotYet
             } else {
                 // If the module has not reached the export stage, return NotYet.
                 val stage = getModule(name.origin)?.stageCompleted

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
@@ -92,13 +92,6 @@ class Module(
      * [lang.temper.value.Abort].
      */
     continueCondition: ContinueCondition,
-    /**
-     * Whether staging ends with the last stage before [Stage.Run] or whether execution may
-     * proceed to [Stage.Run].
-     * Modules that may be run might have [exports] and other derived information that come from
-     * running instead of being derived from partial interpretation.
-     */
-    val mayRun: Boolean = false,
     sharedLocationContext: SharedLocationContext? = null,
     override val genre: Genre = Genre.Library,
     allowDuplicateLogPositions: Boolean = false,
@@ -145,10 +138,10 @@ class Module(
     init {
         val cc = continueCondition
 
-        // We need questions like canAdvance to be repeatable so don't want to call stateful
+        // We need questions like canAdvance to be repeatable, so don't want to call stateful
         // functions like continueCondition directly.
         // Instead, we wrap it to flip a bit on its first false return.
-        // This has the side effect of also making this.continueCondition monotonic which is nice.
+        // This has the side effect of also making `this.continueCondition` monotonic, which is nice.
         data class ContinueConditionWrapper(val cc: ContinueCondition) : ContinueCondition {
             override fun shouldContinue(): Boolean = when {
                 continueConditionReturnedFalse -> false
@@ -177,7 +170,7 @@ class Module(
     }
 
     /**
-     * Wraps an environment to expose module accessible, but not module mutable bindings.
+     * Wraps an environment to expose module-accessible, but not module-mutable bindings.
      * This is used by [interpretiveDanceStage] to wrap the builtin environment with an environment
      * from the compiler.  For example, a non-preface module will bring preface module declarations
      * into scope.
@@ -203,7 +196,7 @@ class Module(
     }
 
     /**
-     * An outer module which is implicitly imported during [Stage.Import].
+     * An outer module that is implicitly imported during [Stage.Import].
      * This is used to connect a module to its preface.
      * Names exported from the preface are implicitly available to each module instance.
      */
@@ -256,14 +249,14 @@ class Module(
     val runResult get() = _runResult
 
     /**
-     * The name of the variable that will hold the module's result if any.
+     * The name of the variable which will hold the module's result, if any.
      * `null` unless [StagingFlags.moduleResultNeeded] and we have reached [Stage.Type] and
      * run the MakeResultsExplicit pass.
      */
     val outputName get() = _outputName
 
     /**
-     * The stay for a placeholder declaration that holds metadata related to the module as a whole.
+     * The stay for a placeholder declaration which holds metadata related to the module as a whole.
      */
     var topLevelMetadataStay: StayLeaf? = null
         internal set
@@ -309,12 +302,12 @@ class Module(
      *
      * This will eventually be used to:
      * - allow tools like linters to store per-file configuration
-     * - allow versioning the language, by running a one-time tool over all legacy files that adds
+     * - allow versioning the language by running a one-time tool over all legacy files that adds
      *   `{ "Temper": { "languageVersion": "1.0-deprecated" } }`
      * - allow opting legacy files out of error checks added to the compiler after they were written
      *   by running a one-time tool over legacy files
      *
-     * so that when users start from a blank file, they're opting into the newest, strictest
+     * This means that when users start from a blank file, they're opting into the newest, strictest
      * version of the language.
      */
     var appendix: JsonValue? = null
@@ -620,17 +613,14 @@ class Module(
         Stage.Import,
         Stage.DisAmbiguate,
         Stage.SyntaxMacro,
-        ->
-            _tree != null
         Stage.Define,
         Stage.Type,
         Stage.FunctionMacro,
         Stage.Export,
         Stage.Query,
         Stage.GenerateCode,
-        ->
-            _tree != null
-        Stage.Run -> mayRun && _tree != null
+        Stage.Run,
+        -> _tree != null
     }
 
     private fun complete(stage: Stage, failMark: FailLog.FailMark, ok: Boolean, done: () -> Unit) {

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/ExportChecker.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/ExportChecker.kt
@@ -37,7 +37,7 @@ import lang.temper.value.wordSymbol
 internal class ExportChecker(val module: Module) {
     private val exportedTypeNames = buildSet exportedTypes@{
         exports@ for (export in module.exports ?: listOf()) {
-            val value = export.value ?: continue@exports
+            val value = export.valueFromStaging ?: continue@exports
             val type = TType.unpackOrNull(value)?.type2 as? NonNullType ?: continue@exports
             add(type.definition.name)
         }
@@ -55,7 +55,7 @@ internal class ExportChecker(val module: Module) {
 
     fun checkExports() {
         exportChecks@ for (export in module.exports ?: return) {
-            val value = export.value
+            val value = export.valueFromStaging
             when (value?.typeTag) {
                 is TType -> TType.unpack(value).type2.let { type ->
                     (type as? NonNullType)?.let { checkTypeDefinition(it.definition) }
@@ -161,8 +161,7 @@ internal class ExportChecker(val module: Module) {
     private fun checkTypeDefinition(def: TypeDefinition) {
         val shape = def as? TypeShape
         // General stay leaf includes constructor.
-        // val pos = shape?.stayLeaf?.pos ?: def.pos
-        // Name alone excludes extends clause, but less likely to be huge or include other types.
+        // Name alone excludes the `extends` clause, but it's less likely to be huge or include other types.
         val pos = (shape?.stayLeaf?.incoming?.source as? DeclTree)?.parts?.name?.pos ?: def.pos
         // Param bounds.
         for (formal in def.formals) {

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/GenerateCodeStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/generate/GenerateCodeStage.kt
@@ -42,7 +42,7 @@ import lang.temper.value.void
 private const val BENCHMARK = false
 
 /**
- * A stage that runs just before module contents is passed to backends.  It makes sure that all the
+ * A stage that runs just before the module content is passed to backends.  It makes sure that all the
  * ducks are in a row; that the TmpL translator will be able to recreate a statement / expression
  * layering without introducing temporaries.
  */

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/implicits/ImplicitsModule.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/implicits/ImplicitsModule.kt
@@ -89,7 +89,6 @@ object ImplicitsModule {
             console = moduleConsole,
             continueCondition = NeverStop,
             namingContext = WellKnownTypes.anyValueTypeDefinition.name.origin,
-            mayRun = true, // TODO Remove this option once `console` is a stable value.
         )
 
         module.deliverContent(
@@ -99,7 +98,7 @@ object ImplicitsModule {
                 languageConfig = StandaloneLanguageConfig,
             ),
         )
-        val endStage = Stage.Run // TODO Go back to Stage.GenerateCode once `console` is a stable value.
+        val endStage = Stage.Run
         stageLoop@
         while (module.canAdvance()) {
             val nextStage = module.nextStage!!
@@ -202,12 +201,12 @@ internal class ImplicitsUnavailableException(message: String) : RuntimeException
 private val allImplicitlyImportedNamesLazy = lazy {
     // If this throws because `module` is bootstrapping, lazy will try again later.
     (ImplicitsModule.module.exports ?: emptyList()).associate { export ->
-        BuiltinName(export.name.baseName.nameText) as TemperName to export.value!!
+        BuiltinName(export.name.baseName.nameText) as TemperName to export.valueFromRun!!
     }
 }
 
 /**
- * Not-super-efficient accessor for the list of names implicitly exported
+ * Not-superefficient accessor for the list of names implicitly exported
  */
 val allImplicitlyImportedNames: Map<TemperName, Value<*>>
     get() = try {

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/importstage/ImportStage.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/importstage/ImportStage.kt
@@ -43,11 +43,11 @@ import lang.temper.value.BlockTree
 import lang.temper.value.CallTree
 import lang.temper.value.InterpreterCallback
 import lang.temper.value.InterpreterCallback.NullInterpreterCallback.logSink
-import lang.temper.value.ReifiedType
 import lang.temper.value.RightNameLeaf
 import lang.temper.value.TBoolean
 import lang.temper.value.TClass
 import lang.temper.value.TFunction
+import lang.temper.value.TProblem
 import lang.temper.value.TString
 import lang.temper.value.TSymbol
 import lang.temper.value.TType
@@ -122,7 +122,7 @@ private fun maybeImportImplicits(
         } catch (ex: ImplicitsUnavailableException) {
             // It's nice to be able to debug problems with implicits via unit tests that do not
             // need implicits to work.
-            // Swallow any trouble getting the implicits module so that those tests can continue,
+            // Swallow any trouble getting the implicits module so that those tests can continue
             // and use a separate unit test to check that the implicits module stages properly.
             ignore(ex)
             null
@@ -237,7 +237,7 @@ private fun maybeImportImplicits(
             adjustedAdditionalImplicitImports.forEach { export ->
                 // If we import names that weren't mentioned, then the REPL session
                 // ends up linking every Module to every Module with a top-level
-                // definition which means that the cost of the ReplTranslateFn
+                // definition, which means that the cost of the ReplTranslateFn
                 // grows with the size of the REPL session.
                 // By only importing those names that could be resolved to, we
                 // limit that growth significantly.
@@ -281,9 +281,9 @@ val Export.optionallyImported: Boolean get() {
     if (optionalImportSymbol !in this.declarationMetadata) {
         return false
     }
-    // Names of instantiable types can be resolved to by property bags, so we
+    // To resolve property bags, we need names of instantiable types, so we
     // do not prune those.
-    val typeShape = this.value?.typeShapeAtLeafOrNull
+    val typeShape = this.valueFromStaging?.typeShapeAtLeafOrNull
     return !(typeShape != null && typeShape.abstractness == Abstractness.Concrete)
 }
 
@@ -324,7 +324,7 @@ private fun adjustAdditionalImplicitImports(imports: List<Export>, root: BlockTr
     }.visitPreOrder()
     requiredModuleNames.isNotEmpty() || return imports
     return imports.map imports@{ import ->
-        val value = import.value ?: return@imports import
+        val value = import.valueFromStaging ?: return@imports import
         val loc = value.loc() ?: return@imports import
         when {
             loc in requiredModuleNames -> import.copy(
@@ -344,8 +344,9 @@ private fun Value<*>.loc(): CodeLocation? {
         // This actually gets the loc of the type, which is good enough for current needs.
         is TClass -> tag.typeShape.pos
         // And we don't actually even need TFunction right now, but I had an example to work from so supported that.
-        is TFunction -> (stateVector as? UserFunction)?.pos
-        is TType -> ((stateVector as? ReifiedType)?.type as? NominalType)?.definition?.pos
+        is TFunction -> (TFunction.unpack(this) as? UserFunction)?.pos
+        is TType -> (TType.unpack(this).type as? NominalType)?.definition?.pos
+        is TProblem -> TProblem.unpack(this).pos
         else -> null
     }?.loc
 }

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/json/MixinJsonInterop.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/json/MixinJsonInterop.kt
@@ -116,7 +116,7 @@ internal fun mixinJsonInterop(
     fun lookupStdJsonExport(nameText: String): TypeShape? {
         val baseName = ParsedName(nameText)
         val e = stdJsonModule.exports?.firstOrNull { it.name.baseName == baseName }
-        val ts = (TType.unpackOrNull(e?.value)?.type2 as? DefinedNonNullType)
+        val ts = (TType.unpackOrNull(e?.valueFromStaging)?.type2 as? DefinedNonNullType)
             ?.definition
         if (ts == null) {
             logSink.log(
@@ -399,7 +399,6 @@ private fun stageGeneratedCodeAndFoldIntoModule(
         loc = module.loc,
         console = module.console,
         continueCondition = module.continueCondition,
-        mayRun = false,
         sharedLocationContext = module.sharedLocationContext,
         genre = Genre.Library,
         allowDuplicateLogPositions = module.allowDuplicateLogPositions,

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/LibraryConfigurationFromConfigModule.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/LibraryConfigurationFromConfigModule.kt
@@ -19,8 +19,8 @@ fun libraryConfigurationFromConfigModule(
         libraryRoot = moduleName.libraryRoot(),
         supportedBackendList = guessLibraryConfiguration?.supportedBackendList ?: emptyList(),
         classifyTemperSource = guessLibraryConfiguration?.classifyTemperSource ?: ::defaultClassifyTemperSource,
-        configExports = module.exports?.filter { it.value != null }?.associate {
-            it.name.baseName.toSymbol() to it.value!!
+        configExports = module.exports?.filter { it.valueFromStaging != null }?.associate {
+            it.name.baseName.toSymbol() to it.valueFromStaging!!
         } ?: emptyMap(),
     )
 }

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/LibraryNameFor.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/LibraryNameFor.kt
@@ -36,7 +36,9 @@ fun libraryNameWithDefault(textContent: String, module: Module?, rootPath: FileP
 fun libraryNameForModule(module: Module?, fallback: () -> DashedIdentifier?): DashedIdentifier {
     // Try the most explicit option first.
     val nameExport = module?.exports?.find { it.name.baseName == LibraryConfiguration.libraryNameParsedName }
-    val explicitName = nameExport?.let { TString.unpackOrNull(it.value) }?.let { DashedIdentifier.from(it) }
+    val explicitName = nameExport
+        ?.let { TString.unpackOrNull(it.valueFromStaging) }
+        ?.let { DashedIdentifier.from(it) }
     if (explicitName != null) { return explicitName }
     // But be willing to guess from other hints so we can proceed.
     // TODO Give an error/warning but proceed for any of the backup strategies?

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/ModuleAdvancer.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/ModuleAdvancer.kt
@@ -10,6 +10,7 @@ import lang.temper.common.buildListMultimap
 import lang.temper.common.compatReversed
 import lang.temper.common.console
 import lang.temper.common.partiallyOrder
+import lang.temper.common.partiallyOrderTo
 import lang.temper.common.putMultiList
 import lang.temper.env.Exporter
 import lang.temper.env.InterpMode
@@ -249,7 +250,6 @@ class ModuleAdvancer(
         loc: ModuleName,
         console: Console,
         continueCondition: ContinueCondition = makeContinueCondition(),
-        mayRun: Boolean = moduleConfig.mayRun,
         allowDuplicateLogPositions: Boolean = false,
         genre: Genre = Genre.Library,
     ): Module {
@@ -258,7 +258,6 @@ class ModuleAdvancer(
             loc = loc,
             console = console,
             continueCondition = continueCondition,
-            mayRun = mayRun,
             sharedLocationContext = sharedLocationContext,
             genre = genre,
             allowDuplicateLogPositions = allowDuplicateLogPositions,
@@ -361,7 +360,7 @@ class ModuleAdvancer(
     fun getAllLibraryConfigurations(): List<LibraryConfiguration> = libraryConfigurations.toList()
     fun getLibraryConfiguration(libraryRoot: FilePath) = libraryConfigurations[libraryRoot]
 
-    fun advanceModules(stopBefore: Stage? = null) = advanceModules { stopBefore }
+    fun advanceModules(stopBefore: Stage?) = advanceModules { stopBefore }
 
     private data class NonLocalLookup(
         val nonLocalImportResolver: ImportResolver,
@@ -401,20 +400,6 @@ class ModuleAdvancer(
          */
         stopBefore: (Module) -> Stage?,
     ) {
-        // If any of the input modules are mayRun, then assume the caller is going
-        // to want to run the std modules and don't reuse the non-may-run modules.
-        val sharedStdModules = if (moduleConfig.mayRun || modules.any { it.mayRun }) {
-            lazy {
-                buildStdModules(
-                    this,
-                    console,
-                    mayRun = true,
-                )
-            }
-        } else {
-            sharedStdModulesMayNotRun
-        }
-
         val nonLocalLookup = NonLocalLookup(nonLocalImportResolver, sharedStdModules)
 
         for (libraryName in requiredLibraries) {
@@ -644,18 +629,52 @@ private class GroupOfModulesToAdvanceTogether(
             }
         }
 
-        val readyToAdvance = ArrayDeque(modules)
+        // We keep a queue of modules to advance and implement additional
+        // checks while looping over it to delay when waiting for imports.
+        val readyToAdvance = ArrayDeque<Module>()
+        // For Stage.Run emulation, we need to queue modules in a specific
+        // order because the run stage can perform side effects.
+        // So we collect modules that are ready to run here, off the queue,
+        // and once everything is ready to enter the run stage, we empty
+        // this set back onto the queue in the right order.
+        var readyToRun: MutableSet<Module>? = mutableSetOf()
+        for (m in modules) {
+            if (m.stageCompleted == stageBeforeRun && !m.isConfigModule) {
+                readyToRun!!.add(m)
+            } else {
+                readyToAdvance.add(m)
+            }
+        }
+
         while (true) {
             val m = readyToAdvance.removeFirstOrNull()
-                ?: if (tryBreakCycle(readyToAdvance)) {
-                    // If nothing was ready because of an import cycle, try again.
-                    continue
-                } else {
-                    break
+                ?: run {
+                    // If nothing was ready because of import cycle(s), break them and try again.
+                    do {
+                        if (!tryBreakCycle(readyToAdvance)) { break }
+                    } while (readyToAdvance.isEmpty())
+
+                    // If all the modules that can advance to the run stage are ready to do so,
+                    // re-enqueue them.
+                    readyToRun?.let { readyToRunFull ->
+                        addInOrder(readyToRunFull, readyToAdvance)
+                        readyToRun = null
+                    }
+
+                    if (readyToAdvance.isNotEmpty()) {
+                        continue // Try again
+                    } else {
+                        break
+                    }
                 }
 
             val stopBeforeForCurrentModule = stopBefore(m)
             val lastStageCompleted = m.stageCompleted
+            val isConfigModule = m.isConfigModule
+            if (lastStageCompleted == stageBeforeRun && readyToRun != null && !isConfigModule) {
+                readyToRun!!.add(m)
+                continue
+            }
             val shouldAdvance = when {
                 !m.canAdvance() -> false // Cannot be advanced
                 countNeeded[m] != 0 -> false // Still waiting on imports
@@ -720,7 +739,7 @@ private class GroupOfModulesToAdvanceTogether(
                     }
                     // If a config module is ready to export, use its exports
                     // to finalize the library configuration.
-                    if (m.isConfigModule) {
+                    if (isConfigModule) {
                         val libraryRoot = (loc as ModuleName).libraryRoot()
                         val oldConfig = advancer.getLibraryConfiguration(libraryRoot)
                         val newConfiguration = libraryConfigurationFromConfigModule(m, oldConfig)
@@ -735,7 +754,7 @@ private class GroupOfModulesToAdvanceTogether(
                 }
 
                 if (m.canAdvance() && countNeeded.getValue(m) == 0) {
-                    val at = if (m.isConfigModule) {
+                    val at = if (isConfigModule) {
                         // Config modules skip the queue so they complete early,
                         // and we can get their export metadata available in
                         // LibraryConfigurations quickly
@@ -935,7 +954,6 @@ private class ImportHandler(
 private fun buildStdModules(
     advancer: ModuleAdvancer,
     console: Console,
-    mayRun: Boolean,
 ): StdModules {
     val tentativeStdLibraryConfiguration = LibraryConfiguration(
         libraryName = DashedIdentifier.temperStandardLibraryIdentifier,
@@ -944,7 +962,7 @@ private fun buildStdModules(
         classifyTemperSource = ::defaultClassifyTemperSource,
     )
     advancer.configureLibrary(tentativeStdLibraryConfiguration)
-    val stdModuleConfig = ModuleConfig.default.copy(mayRun = mayRun)
+    val stdModuleConfig = ModuleConfig.default.copy(mayRun = true)
 
     val fs = accessStdWrapped() ?: throw IOException("Can't access std")
     val snapshot = FilteringFileSystemSnapshot(fs, FileFilterRules.Allow)
@@ -990,14 +1008,7 @@ private fun buildStdModules(
         logSink = advancer.projectLogSink,
         advancer = advancer,
     )
-    val stopBefore = { _: Module ->
-        if (mayRun) {
-            null
-        } else {
-            Stage.Run
-        }
-    }
-    GroupOfModulesToAdvanceTogether(modules, importHandler, advancer, stopBefore = stopBefore)
+    GroupOfModulesToAdvanceTogether(modules, importHandler, advancer, stopBefore = { null })
         .advanceModules()
 
     val stdLibraryConfiguration = // After processing std/config.temper.md
@@ -1055,7 +1066,7 @@ private class ModuleAdvancerContinueConditionImpl : ContinueCondition {
     override fun toString(): String = "ModuleAdvancerContinueConditionImpl(${count[0]})"
 }
 
-private val sharedStdModulesMayNotRun = lazy {
+private val sharedStdModules = lazy {
     val logSink = ConsoleBackedContextualLogSink(
         console,
         null,
@@ -1063,12 +1074,12 @@ private val sharedStdModulesMayNotRun = lazy {
         CustomValueFormatter.Nope,
     )
     val advancer = ModuleAdvancer(logSink)
-    buildStdModules(advancer, console, mayRun = false)
+    buildStdModules(advancer, console)
 }
 
 /** Allows introspective access to std/ modules.  Shared by unit tests.  Do not mutate. */
 fun getSharedStdModules(): List<Module> =
-    sharedStdModulesMayNotRun.value.modulesByFullSpecifier.values.toList()
+    sharedStdModules.value.modulesByFullSpecifier.values.toList()
 
 /** Try to convert a non-local specifier to a local specifier when the importer is in the same library. */
 private fun toLocalSpecifier(
@@ -1241,4 +1252,31 @@ private fun withSnapshotter(
             Debug.Frontend.configure(ck, null)
         }
     }
+}
+
+private val stageBeforeRun = Stage.before(Stage.Run)!!
+
+/** Enqueue in dependency order. */
+private fun addInOrder(modules: Iterable<Module>, out: MutableCollection<Module>) {
+    val afterMap = mutableMapOf<Module, MutableSet<Module>>()
+    for (m in modules) {
+        afterMap[m] = mutableSetOf<Module>()
+    }
+    for (m in modules) {
+        for (ir in m.importRecords) {
+            val afterSet = afterMap.getValue(m)
+            when (ir) {
+                is Importer.BadImportRecord -> {}
+                is Importer.OkImportRecord -> if (ir.isBlockingImport) {
+                    (ir.exporter as? Module)?.let { exportingModule ->
+                        if (exportingModule in afterMap) {
+                            // importers go after exporters
+                            afterSet.add(exportingModule)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    partiallyOrderTo(modules, afterMap, out) { it }
 }

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/SourceFilePartition.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/staging/SourceFilePartition.kt
@@ -207,7 +207,7 @@ class SourceFilePartition(
         }
         // Modules need rebuilding in these situations:
         // 1. There is no prior module to reuse, or
-        // 2. their source hashes are not the same as those of the prior module, or
+        // 2. their source hashes are different from those of the prior module, or
         // 3. they had a failed import, and there is a new module (see 1), or
         // 4. one of their dependencies needs rebuilding, transitively.
         // Initialize needsRebuild based on situation 1
@@ -250,7 +250,7 @@ class SourceFilePartition(
                     needsRebuild[moduleName] = true
                 } else if (!moduleName.isPreface) {
                     // There's a new import implicitly if the named module
-                    // has a new preface, but did not previously.
+                    // has a new preface but did not previously.
                     // This may be redundant as there's no way to get this without a
                     // hash change due to the added `;;;` token checked in situation 2.
                     val prefaceLoc = moduleName.copy(isPreface = true)
@@ -296,8 +296,8 @@ class SourceFilePartition(
         }
 
         // Figure out what needs building and what doesn't.
-        // We store these sets for test harnesses to use, but also use them to decide how
-        // to populate the module advancer with library configurations and modules.
+        // We store these sets for test harnesses to use but also use them to decide how
+        // to populate the ModuleAdvancer with library configurations and modules.
         val newLibraryRoots = mutableSetOf<FilePath>()
         val reusedLibraryRoots = mutableSetOf<FilePath>()
         val droppedLibraryRoots = mutableSetOf<FilePath>()
@@ -325,7 +325,7 @@ class SourceFilePartition(
         for (libraryRoot in priorLibraryConfigurations.keys) {
             if (libraryRoot !in plannedLibraryRoots) {
                 // Don't send library roots to the module advancer when all source files
-                // have been deleted which happens for mass deletes and directory renames.
+                // have been deleted, which happens for mass deletes and directory renames.
                 droppedLibraryRoots.add(libraryRoot)
                 notifyLibraryDropped(projectLogSink, libraryRoot)
             } else {
@@ -384,7 +384,6 @@ class SourceFilePartition(
                     loc = moduleName,
                     console = console,
                     continueCondition = makeAContinueCondition(),
-                    mayRun = moduleConfig.mayRun,
                     genre = plan.genre,
                 )
                 module.deliverContent(plan.sources)

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/AssertModuleAtStage.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/AssertModuleAtStage.kt
@@ -259,7 +259,6 @@ fun assertModuleAtStage(
         loc = moduleLoc,
         console = console,
         continueCondition = continueCondition,
-        mayRun = true,
         genre = genre,
         allowDuplicateLogPositions = true,
     )

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/DefineStageTest.kt
@@ -2163,7 +2163,6 @@ class DefineStageTest {
                 loc = loc,
                 console = console,
                 continueCondition = { true },
-                mayRun = false,
             )
             fakeStdModule.deliverContent(
                 ModuleSource(
@@ -2782,7 +2781,7 @@ class DefineStageTest {
                     languageConfig = StandaloneLanguageConfig,
                 ),
             )
-            moduleAdvancer.advanceModules()
+            moduleAdvancer.advanceModules(null)
             moduleAdvancer.getAllModules()
         }
         assertStructure(

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/InterpreterFunctionalTests.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/InterpreterFunctionalTests.kt
@@ -154,7 +154,9 @@ class InterpreterFunctionalTests : FunctionalTestSuiteI {
             test.runAsTest -> {
                 val reportName = ExportedName(mainModule.namingContext, testReportExportName)
                 // Expect these things for any runAsTest funtest.
-                val reportText = TString.unpack(mainModule.exports!!.find { it.name == reportName }!!.value!!)
+                val reportText = TString.unpack(
+                    mainModule.exports!!.find { it.name == reportName }!!.valueFromRun!!,
+                )
                 assertTestingTestFromJunit(
                     test = test,
                     junitOutput = reportText,

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/implicits/ImplicitsModuleTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/implicits/ImplicitsModuleTest.kt
@@ -1,10 +1,10 @@
 package lang.temper.frontend.implicits
 
 import lang.temper.common.ignore
+import lang.temper.common.soleElementOrNull
 import lang.temper.interp.EmptyEnvironment
 import lang.temper.lexer.Genre
 import lang.temper.name.BuiltinName
-import lang.temper.type.ANY_VALUE_TYPE_NAME_TEXT
 import lang.temper.type.MethodShape
 import lang.temper.type.WellKnownTypes
 import lang.temper.type.promoteSimpleValue
@@ -30,12 +30,17 @@ class ImplicitsModuleTest {
 
     @Test
     fun implicitsExportsAnyValue() {
+        val export = ImplicitsModule.module.exports?.filter { it.name.baseName.nameText == "AnyValue" }
+            ?.soleElementOrNull
         assertEquals(
-            true,
-            ImplicitsModule.module.exports?.any {
-                it.name.baseName.nameText == ANY_VALUE_TYPE_NAME_TEXT &&
-                    it.value?.typeDefinitionAtLeafOrNull == WellKnownTypes.anyValueTypeDefinition
-            },
+            listOf(
+                WellKnownTypes.anyValueTypeDefinition,
+                WellKnownTypes.anyValueTypeDefinition,
+            ),
+            listOf(
+                export?.valueFromStaging?.typeDefinitionAtLeafOrNull,
+                export?.valueFromRun?.typeDefinitionAtLeafOrNull,
+            ),
         )
     }
 

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/json/JsonInteropTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/json/JsonInteropTest.kt
@@ -20,6 +20,7 @@ import lang.temper.name.ResolvedName
 import lang.temper.name.ResolvedNameMaker
 import lang.temper.name.SourceName
 import lang.temper.name.Symbol
+import lang.temper.stage.Stage
 import lang.temper.type.Abstractness
 import lang.temper.type.NominalType
 import lang.temper.type.StaticType
@@ -27,7 +28,6 @@ import lang.temper.type.TypeShape
 import lang.temper.type.TypeTestHarness
 import lang.temper.value.Document
 import lang.temper.value.DocumentContext
-import lang.temper.value.ReifiedType
 import lang.temper.value.TInt
 import lang.temper.value.TString
 import lang.temper.value.TType
@@ -739,7 +739,7 @@ private val stdJsonForTest = lazy {
             languageConfig = StandaloneLanguageConfig,
         ),
     )
-    advancer.advanceModules()
+    advancer.advanceModules(stopBefore = Stage.Run)
     val stdJsonModule = advancer.getAllModules().first {
         val loc = it.loc
         (
@@ -755,7 +755,7 @@ private val stdJsonForTest = lazy {
     val exports = stdJsonModule.exports!!
     fun typeShapeNamed(exportName: String): TypeShape {
         val export = exports.first { it.name.baseName.nameText == exportName }
-        val exportedType = (TType.unpack(export.value!!) as ReifiedType).type
+        val exportedType = TType.unpack(export.valueFromStaging!!).type
         return (exportedType as NominalType).definition as TypeShape
     }
     JsonInteropDetails.StdJson(

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/staging/ModuleAdvancerTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/staging/ModuleAdvancerTest.kt
@@ -350,6 +350,83 @@ class ModuleAdvancerTest {
     )
 
     @Test
+    fun runningHappensInOrder() = assertVerboseLogOutput(
+        """
+            |{
+            |  a: {
+            |    "impl.temper":
+            |        ```
+            |        let { f } = import("../b/");
+            |        let { g } = import("../c/");
+            |        g();
+            |        f();
+            |        console.log("a initialized.");
+            |        ```,
+            |  },
+            |  b: {
+            |    "impl.temper":
+            |        ```
+            |        export let f(): Void { console.log("b: f() called."); }
+            |        console.log("b initialized.");
+            |        ```,
+            |  },
+            |  c: {
+            |    "impl.temper":
+            |        ```
+            |        let { f } = import("../b/");  // Fix import order between b and c
+            |        export let g(): Void { console.log("c: g() called."); }
+            |        console.log("c initialized.");
+            |        ignore(f);
+            |        ```,
+            |  }
+            |}
+        """.trimMargin(),
+        """
+            |[work/]: Library found
+            |[work//a/]: Pre-staging module from [work/a/impl.temper]
+            |[work//b/]: Pre-staging module from [work/b/impl.temper]
+            |[work//c/]: Pre-staging module from [work/c/impl.temper]
+            |[work//a/]: Starting stage @L
+            |[work//b/]: Starting stage @L
+            |[work//c/]: Starting stage @L
+            |[work//a/]: Starting stage @P
+            |[work//b/]: Starting stage @P
+            |[work//c/]: Starting stage @P
+            |[work//a/]: Starting stage @I
+            |[work//b/]: Starting stage @I
+            |[work//c/]: Starting stage @I
+            |## All modules have reached the import stage, but a/ is waiting on b/ and c/
+            |## And b/ is also waiting on c/
+            |[work//b/]: Starting stage @A..X
+            |## Now, b/ has exported which unlocks c/ to proceed.
+            |[work//c/]: Starting stage @A
+            |[work//b/]: Starting stage @Q
+            |[work//c/]: Starting stage @S
+            |[work//b/]: Starting stage @G
+            |[work//c/]: Starting stage @D..X
+            |## Now, b/ and c/ have both exported which unlocks a/ to proceed.
+            |[work//a/]: Starting stage @A
+            |[work//c/]: Starting stage @Q
+            |[work//a/]: Starting stage @S
+            |[work//c/]: Starting stage @G
+            |[work//a/]: Starting stage @D..G
+            |## Now all of them have completed @G, so they can run.
+            |## Note that b/ and c/ proceed a/ since the run stage requires that they
+            |## be initialized before a can run functions from them.
+            |[work//b/]: Starting stage @R
+            |[implicits/Implicits.temper+#-#]@R: Print: b initialized.
+            |[work//c/]: Starting stage @R
+            |[implicits/Implicits.temper+#-#]@R: Print: c initialized.
+            |[work//a/]: Starting stage @R
+            |[implicits/Implicits.temper+#-#]@R: Print: c: g() called.
+            |[implicits/Implicits.temper+#-#]@R: Print: b: f() called.
+            |[implicits/Implicits.temper+#-#]@R: Print: a initialized.
+            |Bye
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+        stopBefore = null,
+    )
+
+    @Test
     fun importBySelfLibraryNameWorksWhenNameExportedFromConfig() = assertVerboseLogOutput(
         """
             |{
@@ -459,9 +536,11 @@ class ModuleAdvancerTest {
         fileTreeJson: String,
         wantedLogOutput: String,
         level: Log.LevelFilter = Log.Fine,
+        stopBefore: Stage? = Stage.Run,
     ) {
         assertVerboseLogOutputReturnAdvancer(
             fileTreeJson = fileTreeJson, wantedLogOutput = wantedLogOutput, level = level,
+            stopBefore = stopBefore,
         )
     }
 
@@ -469,6 +548,7 @@ class ModuleAdvancerTest {
         fileTreeJson: String,
         wantedLogOutput: String,
         level: Log.LevelFilter = Log.Fine,
+        stopBefore: Stage? = Stage.Run,
     ): ModuleAdvancer {
         val workDir = dirPath("work")
         val fileTreeObj = JsonObject(
@@ -503,15 +583,19 @@ class ModuleAdvancerTest {
                 },
             )
 
-            advancer.advanceModules()
+            advancer.advanceModules(stopBefore = stopBefore)
             // AllDone has effect of flushing log sink
             logSink.log(Log.Fine, MessageTemplate.AllDone, unknownPos, emptyList())
         }
 
-        assertEquals(wantedLogOutput.trimEnd(), stdout.trimEnd())
+        // Editing Implicits.temper should not break tests.
+        val stdoutNormalized = stdout.trimEnd().replace(implicitsPosition, "[$1+#-#]")
+        assertEquals(wantedLogOutput.trimEnd(), stdoutNormalized)
         return advancer
     }
 }
+
+private val implicitsPosition = Regex("""^\[(implicits/Implicits\.temper)\+\d+-\d+]""", RegexOption.MULTILINE)
 
 /** Collapses adjacent "Starting stage ..." messages into one */
 private class LessSpammyLogSink(private val logSink: LogSink) : LogSink {

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/staging/SourceFilePartitionTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/staging/SourceFilePartitionTest.kt
@@ -14,6 +14,7 @@ import lang.temper.log.FilePath
 import lang.temper.log.FilePathSegment
 import lang.temper.log.dirPath
 import lang.temper.name.DashedIdentifier
+import lang.temper.stage.Stage
 import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -712,7 +713,7 @@ private class SourceFilePartitionTestHarness {
         sourceFilePartition.scan(snapshot, workRootDir)
         sourceFilePartition.addModulesToAdvancer()
 
-        moduleAdvancer.advanceModules()
+        moduleAdvancer.advanceModules(stopBefore = Stage.Run)
         assertStructure(
             jsonPartition,
             projectLogSink.wrapErrorsAround(

--- a/fundamentals/src/commonMain/kotlin/lang/temper/env/Exporter.kt
+++ b/fundamentals/src/commonMain/kotlin/lang/temper/env/Exporter.kt
@@ -8,6 +8,7 @@ import lang.temper.log.Position
 import lang.temper.name.ExportedName
 import lang.temper.name.ModuleLocation
 import lang.temper.name.Symbol
+import lang.temper.stage.Stage
 import lang.temper.value.StayReferrer
 import lang.temper.value.StaySink
 import lang.temper.value.TString
@@ -26,7 +27,27 @@ interface Exporter {
 data class Export(
     val exporter: Exporter,
     val name: ExportedName,
-    val value: Value<*>?,
+    /**
+     * The value for any [Stage] before [Stage.Run].
+     * This is the statically knowable value.
+     *
+     * It is likely to be `null` in many cases where, at runtime we can produce
+     * a value.
+     *
+     * For example, `export let profilingStartStamp = MonotonicClock.now()`
+     * depends on runtime information.  We cannot compute that statically
+     * because there are no stable compile-time semantics for the module
+     * load time.
+     *
+     * In some cases, macro function values, we might have this value but
+     * not one for [valueFromRun].  Macros are not necessary after
+     * the [Stage.GenerateCode] stage completes.
+     */
+    val valueFromStaging: Value<*>?,
+    /**
+     * Unlike [valueFromStaging], the value from runtime.
+     */
+    val valueFromRun: Value<*>?,
     val typeInferences: TypeInferences?,
     val declarationMetadata: Map<Symbol, List<Value<*>?>>,
     val position: Position,
@@ -42,6 +63,14 @@ data class Export(
     override val reifiedType: Value<*>?
         get() = null // Could we get one from typeInferences?
 
+    /**
+     * Picks the exported value based on the semantics of the stage requesting it.
+     */
+    fun value(stage: Stage): Value<*>? = when (stage) {
+        Stage.Run -> valueFromRun
+        else -> valueFromStaging
+    }
+
     val connectedKey: String?
         get() = when {
             connectedSymbol in declarationMetadata ->
@@ -50,16 +79,21 @@ data class Export(
         }
 
     override fun addStays(s: StaySink) {
-        if (value != null) {
-            s.whenUnvisited(value) {
-                value.addStays(s)
+        valueFromStaging?.let {
+            s.whenUnvisited(it) {
+                it.addStays(s)
+            }
+        }
+        valueFromRun?.let {
+            s.whenUnvisited(it) {
+                it.addStays(s)
             }
         }
         declarationMetadata.forEach { (_, values) ->
-            values.forEach {
-                if (value != null) {
-                    s.whenUnvisited(value) {
-                        value.addStays(s)
+            values.forEach { value ->
+                value?.let {
+                    s.whenUnvisited(it) {
+                        it.addStays(s)
                     }
                 }
             }
@@ -68,7 +102,12 @@ data class Export(
 
     override fun destructure(structureSink: StructureSink) = structureSink.obj {
         key("name") { value(name) }
-        key("value") { value(value) }
+        valueFromStaging.let { value ->
+            key("valueFromStaging", isDefault = value == null) { value(value) }
+        }
+        valueFromRun.let { value ->
+            key("valueFromRun", isDefault = value == null) { value(value) }
+        }
         key("type") { value(typeInferences?.type) }
         key("declarationMetadata") {
             obj {

--- a/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
@@ -2312,6 +2312,7 @@ class Interpreter(
             try {
                 val replacementMaker = callSiteReplacementMaker
                 if (replacementMaker != null) {
+                    require(stage != Stage.Run) // Run stage should not modify the AST
                     val edgeToReplace: TEdge? = callSiteAncestorToReplace ?: call?.incoming
                     require(edgeToReplace != null) {
                         "Cannot determine edge to replace after call to ${callee.toPseudoCode()} in ${call?.toPseudoCode()}"

--- a/interp/src/commonTest/kotlin/lang/temper/interp/InterpreterTest.kt
+++ b/interp/src/commonTest/kotlin/lang/temper/interp/InterpreterTest.kt
@@ -650,6 +650,7 @@ class InterpreterTest {
             |};
             |T
         """.trimMargin(),
+        stage = Stage.GenerateCode,
         expectedJson = """
             |{
             |  result: [ "U__1", "Type" ],

--- a/interp/src/commonTest/kotlin/lang/temper/interp/importExport/CreateLocalBindingsForImportTest.kt
+++ b/interp/src/commonTest/kotlin/lang/temper/interp/importExport/CreateLocalBindingsForImportTest.kt
@@ -174,7 +174,7 @@ class CreateLocalBindingsForImportTest {
      * Some options:
      *
      * - Use the assigned name as a namespace but not as an object, sort of like current `builtins`.
-     * - Reify each module as an objects of an implicit type.
+     * - Reify each module as an object of an implicit type.
      * - Allow some default export as shown here, or maybe defaults just apply to backend generation where
      *   applicable, such as JS.
      */
@@ -330,7 +330,8 @@ private class ExportListBuilder(
             Export(
                 exporter = exporter,
                 name = name,
-                value = value,
+                valueFromStaging = value,
+                valueFromRun = null,
                 typeInferences = typeInferences,
                 declarationMetadata = buildListMultimap {
                     for ((mdKey, mdValue) in declarationMetadata) {

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -170,7 +170,7 @@ fun doBuild(
             doOneBuild(build)
                 // Once we exit the use block, close flips the switch on the
                 // cancel group, preventing any further interpretation using
-                // those modules continue condition.
+                // those modules' continue condition.
                 .also {
                     beforeClose?.invoke(it)
                 }
@@ -247,8 +247,8 @@ private fun stageLibraries(
 
     val modulesPreBuild = moduleAdvancer.getAllModules()
     // If all the modules were already built, we could reuse everything,
-    // then there's no point in doing translation.
-    // But if there's no modules, then we're trivially reusing everything,
+    // and there's no point in doing translation.
+    // But if there are no modules, then we're trivially reusing everything,
     // but may need to fire up the backends at least once to create output
     // directories and metadata files.
     val priorBuildSuffices = modulesPreBuild.isNotEmpty() &&
@@ -260,8 +260,8 @@ private fun stageLibraries(
     val libraryConfigurationsByRoot = mutableMapOf<FilePath, LibraryConfiguration>()
     moduleAdvancer.getAllLibraryConfigurations().forEach {
         var libraryConfiguration = it
-        // Finalize the library configurations bundle
-        // For example, if `std` was auto-staged it might have an empty backends list.
+        // Finalize the library configurations bundle.
+        // For example, if `std` was auto-staged, it might have an empty backends list.
         if (
             libraryConfiguration.supportedBackendList.isEmpty() &&
             libraryConfiguration.libraryName == DashedIdentifier.temperStandardLibraryIdentifier
@@ -683,7 +683,7 @@ internal val Module.hasTests: Boolean
 
 private data class InterpreterTestResults(
     val ok: Boolean,
-    /** The Junit XML report for each module that does testing. */
+    /** The JUnit XML report for each module that does testing. */
     val resultsByModule: Map<ModuleName, String>,
     val consoleOutput: String,
     val details: DoRunResultDetail,
@@ -781,7 +781,7 @@ private fun runInInterpreter(
             } catch (e: Panic) {
                 interpFailure = e
             } catch (
-                // Uncaught exceptions during tests warrant reporting
+                // Uncaught exceptions during tests warrant reporting.
                 @Suppress("TooGenericExceptionCaught")
                 e: Exception,
             ) {
@@ -791,7 +791,7 @@ private fun runInInterpreter(
             if (isTestedModule(module)) {
                 val reportName = ExportedName(module.namingContext, testReportExportName)
                 val report = TString.unpackOrNull(
-                    module.exports?.find { it.name == reportName }?.value,
+                    module.exports?.find { it.name == reportName }?.valueFromRun,
                 ) ?: interpFailure?.let { throwable ->
                     allOk = false
                     TestSuites(


### PR DESCRIPTION
This will eventually simplify executing a method predictively, because you optimistically believe it's side effect free, so can be reordered to compile time.

Those optimistic assumptions are something you can check in an instrumented interpreter.

And predictive execution benefits the secure composition library because there we're predicting the result of context propagation to pick escapers for untrusted inputs based on applying functions to string literals.

Predictive execution was complicated because we were tagging modules as runnable or translatable.
The idea behind that was that modules we want to translate we should not run, because running should change the AST or metadata like exported values.

This commit does two things:

- Changes *Interpreter* to panic if anything done at Stage.Run tries to use the `MacroEnvironment.replace` APIs.
- Changes *Export* so that separate values are kept for staging (when the result is statically determinable) and running (when the result may depend on sources of nondeteriminism only available at runtime).

Further commits will build on it to allow more flexible predictive executaion, by allowing a module to request that its dependencies be advanced to the run stage, and to allow executing a synthesized expression as if in the run stage.