### PR TITLE
Pass connected funtest on all but js and interp

### DIFF
--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
@@ -1144,6 +1144,52 @@ object Cpp {
         }
     }
 
+    /** For string literals, although escapes don't work. */
+    class IncludeLocal(
+        pos: Position,
+        path: LiteralExpr,
+    ) : BaseTree(pos), PreProc {
+        override val operatorDefinition: CppOperatorDefinition?
+            get() = null
+        override val codeFormattingTemplate: CodeFormattingTemplate
+            get() = sharedCodeFormattingTemplate19
+        override val formatElementCount
+            get() = 1
+        override fun formatElement(
+            index: Int,
+        ): IndexableFormattableTreeElement {
+            return when (index) {
+                0 -> this.path
+                else -> throw IndexOutOfBoundsException("$index")
+            }
+        }
+        private var _path: LiteralExpr
+        var path: LiteralExpr
+            get() = _path
+            set(newValue) { _path = updateTreeConnection(_path, newValue) }
+        override fun deepCopy(): IncludeLocal {
+            return IncludeLocal(pos, path = this.path.deepCopy())
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is IncludeLocal && this.path == other.path
+        }
+        override fun hashCode(): Int {
+            return path.hashCode()
+        }
+        init {
+            this._path = updateTreeConnection(null, path)
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships(
+                { n -> (n as IncludeLocal).path },
+            )
+        }
+    }
+
     class IfPreProc(
         pos: Position,
         cond: Expr,
@@ -1156,9 +1202,9 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() =
                 if (ifFalse != null) {
-                    sharedCodeFormattingTemplate19
-                } else {
                     sharedCodeFormattingTemplate20
+                } else {
+                    sharedCodeFormattingTemplate21
                 }
         override val formatElementCount
             get() = 4
@@ -1253,12 +1299,57 @@ object Cpp {
         }
     }
 
-    sealed interface Type : Tree {
-        override fun deepCopy(): Type
-    }
-
     sealed interface Expr : Tree {
         override fun deepCopy(): Expr
+    }
+
+    class LiteralExpr(
+        pos: Position,
+        repr: Raw,
+    ) : BaseTree(pos), Expr {
+        override val operatorDefinition: CppOperatorDefinition?
+            get() = null
+        override val codeFormattingTemplate: CodeFormattingTemplate
+            get() = sharedCodeFormattingTemplate22
+        override val formatElementCount
+            get() = 1
+        override fun formatElement(
+            index: Int,
+        ): IndexableFormattableTreeElement {
+            return when (index) {
+                0 -> this.repr
+                else -> throw IndexOutOfBoundsException("$index")
+            }
+        }
+        private var _repr: Raw
+        var repr: Raw
+            get() = _repr
+            set(newValue) { _repr = updateTreeConnection(_repr, newValue) }
+        override fun deepCopy(): LiteralExpr {
+            return LiteralExpr(pos, repr = this.repr.deepCopy())
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is LiteralExpr && this.repr == other.repr
+        }
+        override fun hashCode(): Int {
+            return repr.hashCode()
+        }
+        init {
+            this._repr = updateTreeConnection(null, repr)
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships(
+                { n -> (n as LiteralExpr).repr },
+            )
+        }
+    }
+
+    sealed interface Type : Tree {
+        override fun deepCopy(): Type
     }
 
     sealed interface Name : Tree, Type, Expr {
@@ -1309,7 +1400,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate21
+            get() = sharedCodeFormattingTemplate23
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1364,7 +1455,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate22
+            get() = sharedCodeFormattingTemplate24
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1413,7 +1504,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate23
+            get() = sharedCodeFormattingTemplate25
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1468,7 +1559,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate24
+            get() = sharedCodeFormattingTemplate26
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1522,7 +1613,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate25
+            get() = sharedCodeFormattingTemplate27
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1568,7 +1659,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate26
+            get() = sharedCodeFormattingTemplate28
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1623,7 +1714,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate27
+            get() = sharedCodeFormattingTemplate29
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1677,7 +1768,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate28
+            get() = sharedCodeFormattingTemplate30
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1722,7 +1813,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate29
+            get() = sharedCodeFormattingTemplate31
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1768,7 +1859,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate30
+            get() = sharedCodeFormattingTemplate32
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1822,7 +1913,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate31
+            get() = sharedCodeFormattingTemplate33
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1868,7 +1959,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate32
+            get() = sharedCodeFormattingTemplate34
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1922,7 +2013,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate33
+            get() = sharedCodeFormattingTemplate35
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1969,9 +2060,9 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() =
                 if (value != null) {
-                    sharedCodeFormattingTemplate34
+                    sharedCodeFormattingTemplate36
                 } else {
-                    sharedCodeFormattingTemplate35
+                    sharedCodeFormattingTemplate37
                 }
         override val formatElementCount
             get() = 1
@@ -2017,7 +2108,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate36
+            get() = sharedCodeFormattingTemplate38
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -2063,7 +2154,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate37
+            get() = sharedCodeFormattingTemplate39
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2116,7 +2207,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate38
+            get() = sharedCodeFormattingTemplate40
         override val formatElementCount
             get() = 0
         override fun deepCopy(): BreakStmt {
@@ -2146,7 +2237,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate39
+            get() = sharedCodeFormattingTemplate41
         override val formatElementCount
             get() = 3
         override fun formatElement(
@@ -2212,9 +2303,9 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() =
                 if (ifFalse != null) {
-                    sharedCodeFormattingTemplate40
+                    sharedCodeFormattingTemplate42
                 } else {
-                    sharedCodeFormattingTemplate41
+                    sharedCodeFormattingTemplate43
                 }
         override val formatElementCount
             get() = 3
@@ -2278,7 +2369,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate42
+            get() = sharedCodeFormattingTemplate44
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2333,7 +2424,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate43
+            get() = sharedCodeFormattingTemplate45
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2387,7 +2478,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate44
+            get() = sharedCodeFormattingTemplate46
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -2433,7 +2524,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate45
+            get() = sharedCodeFormattingTemplate47
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2488,7 +2579,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate46
+            get() = sharedCodeFormattingTemplate48
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2543,7 +2634,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate47
+            get() = sharedCodeFormattingTemplate49
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2590,51 +2681,6 @@ object Cpp {
         }
     }
 
-    class LiteralExpr(
-        pos: Position,
-        repr: Raw,
-    ) : BaseTree(pos), Expr {
-        override val operatorDefinition: CppOperatorDefinition?
-            get() = null
-        override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate48
-        override val formatElementCount
-            get() = 1
-        override fun formatElement(
-            index: Int,
-        ): IndexableFormattableTreeElement {
-            return when (index) {
-                0 -> this.repr
-                else -> throw IndexOutOfBoundsException("$index")
-            }
-        }
-        private var _repr: Raw
-        var repr: Raw
-            get() = _repr
-            set(newValue) { _repr = updateTreeConnection(_repr, newValue) }
-        override fun deepCopy(): LiteralExpr {
-            return LiteralExpr(pos, repr = this.repr.deepCopy())
-        }
-        override val childMemberRelationships
-            get() = cmr
-        override fun equals(
-            other: Any?,
-        ): Boolean {
-            return other is LiteralExpr && this.repr == other.repr
-        }
-        override fun hashCode(): Int {
-            return repr.hashCode()
-        }
-        init {
-            this._repr = updateTreeConnection(null, repr)
-        }
-        companion object {
-            private val cmr = ChildMemberRelationships(
-                { n -> (n as LiteralExpr).repr },
-            )
-        }
-    }
-
     class BinaryExpr(
         pos: Position,
         left: Expr,
@@ -2644,7 +2690,7 @@ object Cpp {
         override val operatorDefinition
             get() = op.opEnum.operatorDefinition
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate49
+            get() = sharedCodeFormattingTemplate50
         override val formatElementCount
             get() = 3
         override fun formatElement(
@@ -2707,7 +2753,7 @@ object Cpp {
         override val operatorDefinition
             get() = op.opEnum.operatorDefinition
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate23
+            get() = sharedCodeFormattingTemplate25
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2762,7 +2808,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate50
+            get() = sharedCodeFormattingTemplate51
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2815,7 +2861,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate51
+            get() = sharedCodeFormattingTemplate52
         override val formatElementCount
             get() = 0
         override fun deepCopy(): ThisExpr {
@@ -2847,7 +2893,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate52
+            get() = sharedCodeFormattingTemplate53
         override val formatElementCount
             get() = 5
         override fun formatElement(
@@ -2981,7 +3027,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate53
+            get() = sharedCodeFormattingTemplate54
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -3027,7 +3073,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate54
+            get() = sharedCodeFormattingTemplate55
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -3371,8 +3417,19 @@ object Cpp {
             ),
         )
 
-    /** `# if {{0}} \n {{1}} \n {{2*}} # else \n {{3}} # endif` */
+    /** `# include {{0}} \n` */
     private val sharedCodeFormattingTemplate19 =
+        CodeFormattingTemplate.Concatenation(
+            listOf(
+                CodeFormattingTemplate.LiteralToken("#", OutputTokenType.Punctuation),
+                CodeFormattingTemplate.LiteralToken("include", OutputTokenType.Word),
+                CodeFormattingTemplate.OneSubstitution(0),
+                CodeFormattingTemplate.NewLine,
+            ),
+        )
+
+    /** `# if {{0}} \n {{1}} \n {{2*}} # else \n {{3}} # endif` */
+    private val sharedCodeFormattingTemplate20 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("#", OutputTokenType.Punctuation),
@@ -3395,7 +3452,7 @@ object Cpp {
         )
 
     /** `# if {{0}} \n {{1}} \n {{2*}} # endif` */
-    private val sharedCodeFormattingTemplate20 =
+    private val sharedCodeFormattingTemplate21 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("#", OutputTokenType.Punctuation),
@@ -3413,8 +3470,12 @@ object Cpp {
             ),
         )
 
+    /** `{{0}}` */
+    private val sharedCodeFormattingTemplate22 =
+        CodeFormattingTemplate.OneSubstitution(0)
+
     /** `# elif {{0}} \n {{1}}` */
-    private val sharedCodeFormattingTemplate21 =
+    private val sharedCodeFormattingTemplate23 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("#", OutputTokenType.Punctuation),
@@ -3426,7 +3487,7 @@ object Cpp {
         )
 
     /** `{{0}} public {{1}}` */
-    private val sharedCodeFormattingTemplate22 =
+    private val sharedCodeFormattingTemplate24 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3436,7 +3497,7 @@ object Cpp {
         )
 
     /** `{{0}} {{1}}` */
-    private val sharedCodeFormattingTemplate23 =
+    private val sharedCodeFormattingTemplate25 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3445,7 +3506,7 @@ object Cpp {
         )
 
     /** `{{0}} {{1}} ;` */
-    private val sharedCodeFormattingTemplate24 =
+    private val sharedCodeFormattingTemplate26 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3455,7 +3516,7 @@ object Cpp {
         )
 
     /** `\{ {{0*}} \}` */
-    private val sharedCodeFormattingTemplate25 =
+    private val sharedCodeFormattingTemplate27 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("{", OutputTokenType.Punctuation),
@@ -3468,7 +3529,7 @@ object Cpp {
         )
 
     /** `/\* {{0}} *\/ {{1}}` */
-    private val sharedCodeFormattingTemplate26 =
+    private val sharedCodeFormattingTemplate28 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("/*", OutputTokenType.Comment),
@@ -3479,7 +3540,7 @@ object Cpp {
         )
 
     /** `{{0}} /\* {{1}} *\/` */
-    private val sharedCodeFormattingTemplate27 =
+    private val sharedCodeFormattingTemplate29 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3490,7 +3551,7 @@ object Cpp {
         )
 
     /** `{{0}} const` */
-    private val sharedCodeFormattingTemplate28 =
+    private val sharedCodeFormattingTemplate30 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3499,7 +3560,7 @@ object Cpp {
         )
 
     /** `{{0}} *` */
-    private val sharedCodeFormattingTemplate29 =
+    private val sharedCodeFormattingTemplate31 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3508,7 +3569,7 @@ object Cpp {
         )
 
     /** `{{0}} < {{1*,}} >` */
-    private val sharedCodeFormattingTemplate30 =
+    private val sharedCodeFormattingTemplate32 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3522,7 +3583,7 @@ object Cpp {
         )
 
     /** `{{0}} ;` */
-    private val sharedCodeFormattingTemplate31 =
+    private val sharedCodeFormattingTemplate33 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3531,7 +3592,7 @@ object Cpp {
         )
 
     /** `{{0}} : {{1}}` */
-    private val sharedCodeFormattingTemplate32 =
+    private val sharedCodeFormattingTemplate34 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3541,7 +3602,7 @@ object Cpp {
         )
 
     /** `goto {{0}} ;` */
-    private val sharedCodeFormattingTemplate33 =
+    private val sharedCodeFormattingTemplate35 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("goto", OutputTokenType.Word),
@@ -3551,7 +3612,7 @@ object Cpp {
         )
 
     /** `return {{0}} ;` */
-    private val sharedCodeFormattingTemplate34 =
+    private val sharedCodeFormattingTemplate36 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("return", OutputTokenType.Word),
@@ -3561,7 +3622,7 @@ object Cpp {
         )
 
     /** `return ;` */
-    private val sharedCodeFormattingTemplate35 =
+    private val sharedCodeFormattingTemplate37 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("return", OutputTokenType.Word),
@@ -3570,7 +3631,7 @@ object Cpp {
         )
 
     /** `throw {{0}} ;` */
-    private val sharedCodeFormattingTemplate36 =
+    private val sharedCodeFormattingTemplate38 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("throw", OutputTokenType.Word),
@@ -3580,7 +3641,7 @@ object Cpp {
         )
 
     /** `try {{0}} catch ( const temper :: core :: TemperBubble & ) {{1}}` */
-    private val sharedCodeFormattingTemplate37 =
+    private val sharedCodeFormattingTemplate39 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("try", OutputTokenType.Word),
@@ -3600,7 +3661,7 @@ object Cpp {
         )
 
     /** `break ;` */
-    private val sharedCodeFormattingTemplate38 =
+    private val sharedCodeFormattingTemplate40 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("break", OutputTokenType.Word),
@@ -3609,7 +3670,7 @@ object Cpp {
         )
 
     /** `switch ( {{0}} ) \{ {{1*}} default : {{2}} \}` */
-    private val sharedCodeFormattingTemplate39 =
+    private val sharedCodeFormattingTemplate41 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("switch", OutputTokenType.Word),
@@ -3629,7 +3690,7 @@ object Cpp {
         )
 
     /** `if ( {{0}} ) {{1}} else {{2}}` */
-    private val sharedCodeFormattingTemplate40 =
+    private val sharedCodeFormattingTemplate42 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("if", OutputTokenType.Word),
@@ -3643,7 +3704,7 @@ object Cpp {
         )
 
     /** `if ( {{0}} ) {{1}}` */
-    private val sharedCodeFormattingTemplate41 =
+    private val sharedCodeFormattingTemplate43 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("if", OutputTokenType.Word),
@@ -3655,7 +3716,7 @@ object Cpp {
         )
 
     /** `while ( {{0}} ) {{1}}` */
-    private val sharedCodeFormattingTemplate42 =
+    private val sharedCodeFormattingTemplate44 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("while", OutputTokenType.Word),
@@ -3667,7 +3728,7 @@ object Cpp {
         )
 
     /** `{{0*}} {{1}}` */
-    private val sharedCodeFormattingTemplate43 =
+    private val sharedCodeFormattingTemplate45 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.GroupSubstitution(
@@ -3679,7 +3740,7 @@ object Cpp {
         )
 
     /** `case {{0}} :` */
-    private val sharedCodeFormattingTemplate44 =
+    private val sharedCodeFormattingTemplate46 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("case", OutputTokenType.Word),
@@ -3689,7 +3750,7 @@ object Cpp {
         )
 
     /** `{{0}} [ {{1}} ]` */
-    private val sharedCodeFormattingTemplate45 =
+    private val sharedCodeFormattingTemplate47 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3700,7 +3761,7 @@ object Cpp {
         )
 
     /** `{{0}} ( {{1*,}} )` */
-    private val sharedCodeFormattingTemplate46 =
+    private val sharedCodeFormattingTemplate48 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3714,7 +3775,7 @@ object Cpp {
         )
 
     /** `{{0}} . {{1}}` */
-    private val sharedCodeFormattingTemplate47 =
+    private val sharedCodeFormattingTemplate49 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3723,12 +3784,8 @@ object Cpp {
             ),
         )
 
-    /** `{{0}}` */
-    private val sharedCodeFormattingTemplate48 =
-        CodeFormattingTemplate.OneSubstitution(0)
-
     /** `{{0}} {{1}} {{2}}` */
-    private val sharedCodeFormattingTemplate49 =
+    private val sharedCodeFormattingTemplate50 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3738,7 +3795,7 @@ object Cpp {
         )
 
     /** `( {{0}} ) {{1}}` */
-    private val sharedCodeFormattingTemplate50 =
+    private val sharedCodeFormattingTemplate51 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("(", OutputTokenType.Punctuation, TokenAssociation.Bracket),
@@ -3749,11 +3806,11 @@ object Cpp {
         )
 
     /** `this` */
-    private val sharedCodeFormattingTemplate51 =
+    private val sharedCodeFormattingTemplate52 =
         CodeFormattingTemplate.LiteralToken("this", OutputTokenType.Word)
 
     /** `[ = {{0*}} ] ( {{1*,}} ) {{2}} -> {{3}} {{4}}` */
-    private val sharedCodeFormattingTemplate52 =
+    private val sharedCodeFormattingTemplate53 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("[", OutputTokenType.Punctuation, TokenAssociation.Bracket),
@@ -3777,7 +3834,7 @@ object Cpp {
         )
 
     /** `, & {{0}}` */
-    private val sharedCodeFormattingTemplate53 =
+    private val sharedCodeFormattingTemplate54 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken(",", OutputTokenType.Punctuation),
@@ -3787,7 +3844,7 @@ object Cpp {
         )
 
     /** `{{0}} :: {{1}}` */
-    private val sharedCodeFormattingTemplate54 =
+    private val sharedCodeFormattingTemplate55 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
@@ -12,8 +12,11 @@ Program ::= stmts%Global*"\n" & "\n";
 // top-levels
 Global = StructDecl | FuncDecl | VarDecl | StructDef | DerivedStructDef | TemplateStructDef | TemplateFuncDef | TemplateFuncDecl | TypeDef | FuncDef | VarDef | PreProc | Comment | Namespace;
 
-PreProc = Define | Undef | Pragma | IncludeGuard | Include | IfPreProc;
+PreProc = Define | Undef | Pragma | IncludeGuard | Include | IncludeLocal | IfPreProc;
+// For more on includes, see https://en.cppreference.com/cpp/preprocessor/include#Notes
 Include ::= "#" & "include" & "<" & path%Raw & ">" & "\n";
+/** For string literals, although escapes don't work. */
+IncludeLocal ::= "#" & "include" & path%LiteralExpr & "\n";
 Define ::= "#" & "define" & name%SingleName & value%Expr? & "\n";
 Undef ::= "#" & "undef" & name%SingleName & "\n";
 Pragma ::= "#" & "pragma" & text%Raw & "\n";

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
@@ -224,10 +224,12 @@ class CppBackend private constructor(
                 fileExtensionMap = mapOf(
                     FileType.Module to lang.ext,
                     FileType.Script to lang.ext,
+                    FileType.Header to HPP_EXT,
                 ),
                 mimeTypeMap = mapOf(
                     FileType.Module to MimeType.cppSource,
                     FileType.Script to MimeType.cppSource,
+                    FileType.Header to MimeType.cppSource,
                 ),
             )
 

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
@@ -11,10 +11,12 @@ import lang.temper.be.tmpl.asReceiverMember
 import lang.temper.be.tmpl.injectSuperCallMethods
 import lang.temper.be.tmpl.mutatingMemberNames
 import lang.temper.common.MimeType
+import lang.temper.common.subListToEnd
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
 import lang.temper.log.FilePath
 import lang.temper.log.FilePathSegment
+import lang.temper.log.asFilePath
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.plus
@@ -131,6 +133,18 @@ class CppBackend private constructor(
             result
         }
 
+        // Connected code.
+        val connectedFiles = buildList {
+            for (file in rawBackendFiles) {
+                MetadataFileSpecification(
+                    // Skip the library name part.
+                    path = file.key.segments.subListToEnd(1).asFilePath(),
+                    mimeType = MimeType.cppSource,
+                    content = file.value,
+                ).also { add(it) }
+            }
+        }
+
         val initPath = filePath(INIT_NAME)
 
         dependenciesBuilder.addMetadata(
@@ -149,7 +163,7 @@ class CppBackend private constructor(
             testNs = testNs,
         )
 
-        return translations + listOf(
+        return translations + connectedFiles + listOf(
             MetadataFileSpecification(
                 path = filePath(MAIN_CPP_FILE),
                 mimeType = MimeType.cppSource,

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
@@ -273,6 +273,9 @@ class CppBuilder(
     fun include(name: String): Cpp.Include =
         Cpp.Include(pos, Cpp.Raw(pos, name))
 
+    fun includeLocal(name: String): Cpp.IncludeLocal =
+        Cpp.IncludeLocal(pos, literal(name))
+
     fun thisExpr(): Cpp.ThisExpr = Cpp.ThisExpr(pos)
 
     // helpers

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -3,7 +3,9 @@ package lang.temper.be.cpp
 import lang.temper.be.Backend
 import lang.temper.be.tmpl.TmpL
 import lang.temper.be.tmpl.TypedArg
+import lang.temper.be.tmpl.isStdLib
 import lang.temper.be.tmpl.mapParameters
+import lang.temper.be.tmpl.parameterDefaultStatementsInfo
 import lang.temper.be.tmpl.referencedNames
 import lang.temper.common.MimeType
 import lang.temper.common.ignore
@@ -43,6 +45,7 @@ import lang.temper.value.TInt64
 import lang.temper.value.TNull
 import lang.temper.value.TProblem
 import lang.temper.value.TString
+import lang.temper.value.connectedSymbol
 
 /** How the C++ backend renders Temper function types. Emitted and matched in one place. */
 private const val STD_FUNCTION_PREFIX = "std::function"
@@ -664,15 +667,16 @@ class CppTranslator(
         val bindings = type.bindings
         val typeArgs = bindings.map { translateType2(it) }
         if (typeArgs.isNotEmpty()) {
-            when {
-                def == WellKnownTypes.functionTypeDefinition ->
+            when (def) {
+                WellKnownTypes.functionTypeDefinition ->
                     return stdFunction(typeArgs.last(), typeArgs.dropLast(1))
-                def in listLikeDefs ->
+                in listLikeDefs ->
                     return sharedPtr(stdVector(typeArgs.first()))
-                def in mapLikeDefs ->
+                in mapLikeDefs ->
                     return sharedPtr(cpp.template(cppBaseTypeForDefinition(def)!!, typeArgs))
-                def == WellKnownTypes.dequeTypeDefinition ->
+                WellKnownTypes.dequeTypeDefinition ->
                     return sharedPtr(cpp.template(cppBaseTypeForDefinition(def)!!, typeArgs))
+                else -> {}
             }
         }
         cppBaseTypeForDefinition(def)?.let { base ->
@@ -746,9 +750,7 @@ class CppTranslator(
             cppBaseTypeForDefinition(def) ?: run {
                 // Check if this is a type formal with a known template parameter name
                 val typeFormalName = typeFormalNames[def] ?: typeFormalNamesByText[typeFormalKey(def)]
-                if (typeFormalName != null) {
-                    typeFormalName
-                } else {
+                typeFormalName ?: run {
                     when (val loc = def.sourceLocation) {
                         ImplicitsCodeLocation -> when (val defName = def.name) {
                             is ExportedName -> translateImplicitsType(defName.baseName.builtinKey)
@@ -2797,7 +2799,7 @@ class CppTranslator(
         // member ordering in TmpL.
         prepopulatePropertyDotNames(topLevel)
         val declaredSetters = mutableSetOf<String>()
-        val structFields = buildList<Cpp.StructPart> {
+        val structFields = buildList {
             // Add virtual destructor for interfaces to enable dynamic_pointer_cast
             if (isInterface) {
                 val dtorName = "~${cpp.name(topLevel.name).id.text}"
@@ -2903,12 +2905,17 @@ class CppTranslator(
         } else {
             formals.map { cpp.name(it.name) }
         }
+        val block = when {
+            topLevel.metadata.any { it.key.symbol == connectedSymbol } && !mod!!.isStdLib ->
+                translateConnectedBody(topLevel, allParamNames)
+            else -> translateBlock(topLevel.body)
+        }
         val func = cpp.func(
             cpp.name(topLevel.name),
             translateType(topLevel.returnType),
             allParamTypes,
             allParamNames,
-            translateBlock(topLevel.body),
+            block,
         )
         if (typeFormals.isNotEmpty()) {
             val templateParams = typeFormals.map { formal ->
@@ -2967,6 +2974,36 @@ class CppTranslator(
         for (key in savedTypeFormalKeys) {
             typeFormalNamesByText.remove(key)
         }
+    }
+
+    private fun translateConnectedBody(
+        fn: TmpL.FunctionDeclaration,
+        paramNames: List<Cpp.SingleName>,
+    ): Cpp.BlockStmt = cpp.pos(fn) {
+        hasConnected = true
+        val defaulting = fn.parameterDefaultStatementsInfo()
+        buildList {
+            for (statement in defaulting.defaultStatements) {
+                addAll(translateStatement(statement))
+            }
+            cpp.callExpr(
+                expr = cpp.name(cpp.name("_connected"), cpp.name(fn.name)),
+                args = buildList {
+                    for ((tmpl, cppName) in fn.parameters.parameters.zip(paramNames)) {
+                        when {
+                            tmpl.optional ->
+                                cpp.name(defaulting.parameterMapping.getValue(tmpl.name.name))
+                            else -> cppName.deepCopy()
+                        }.also { add(it) }
+                    }
+                },
+            ).let { call ->
+                when ((fn.returnType.ot as? TmpL.NominalType)?.typeName?.sourceDefinition) {
+                    WellKnownTypes.voidTypeDefinition -> cpp.exprStmt(call)
+                    else -> cpp.returnStmt(call)
+                }
+            }.also { add(it) }
+        }.let { cpp.blockStmt(it) }
     }
 
     /**
@@ -3182,7 +3219,13 @@ class CppTranslator(
         impl.add(initFuncDef)
     }
 
+    private var mod: TmpL.Module? = null
+
+    /** If any userspace connected functions have been defined. */
+    private var hasConnected: Boolean = false
+
     fun translateModule(mod: TmpL.Module): List<Backend.TranslatedFileSpecification> {
+        this.mod = mod
         includes.clear()
         currentModuleLocation = mod.codeLocation.codeLocation
         preprocessImports(mod)
@@ -3317,6 +3360,9 @@ class CppTranslator(
                     content = cpp.program(
                         buildList {
                             add(cpp.include("$modPath$hppName"))
+                            if (hasConnected) {
+                                add(cpp.includeLocal("_connected.hpp"))
+                            }
                             addAll(namespaced(implVarDecls + impl))
                         },
                     ),

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -2993,7 +2993,7 @@ class CppTranslator(
                         when {
                             tmpl.optional ->
                                 cpp.name(defaulting.parameterMapping.getValue(tmpl.name.name))
-                            else -> cppName.deepCopy()
+                            else -> cppName
                         }.also { add(it) }
                     }
                 },

--- a/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpBackend.kt
+++ b/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpBackend.kt
@@ -29,6 +29,7 @@ import lang.temper.log.FilePath
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
+import lang.temper.log.resolveFile
 import lang.temper.name.BackendId
 import lang.temper.name.BackendMeta
 import lang.temper.name.FileType
@@ -183,6 +184,16 @@ class CSharpBackend(setup: BackendSetup<CSharpBackend>) : Backend<CSharpBackend>
                         else -> {}
                     }
                 }
+            }
+            // Connected source.
+            for (file in rawBackendFiles) {
+                // Skip the library name dir and the file name, and keep the middle
+                val subspace = chooseSubspace(file.key.segments).subList(1, file.key.segments.size - 1)
+                MetadataFileSpecification(
+                    path = dirPath(SRC_PROJECT_DIR).resolve(dirPath(subspace)).resolveFile(file.key.segments.last()),
+                    mimeType = mimeType,
+                    content = file.value,
+                ).also { add(it) }
             }
             // Proj.
             val rootNamespaceByName = names.rootNamespaces.associate { it.first.libraryName.text to it.second }

--- a/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpTranslator.kt
+++ b/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpTranslator.kt
@@ -10,10 +10,12 @@ import lang.temper.be.tmpl.TypedArg
 import lang.temper.be.tmpl.canBeNull
 import lang.temper.be.tmpl.dependencyCategory
 import lang.temper.be.tmpl.isCommonlyImplied
+import lang.temper.be.tmpl.isStdLib
 import lang.temper.be.tmpl.isYieldingStatement
 import lang.temper.be.tmpl.libraryName
 import lang.temper.be.tmpl.mapParameters
 import lang.temper.be.tmpl.orInvalid
+import lang.temper.be.tmpl.parameterDefaultStatementsInfo
 import lang.temper.be.tmpl.toSigBestEffort
 import lang.temper.be.tmpl.typeOrInvalid
 import lang.temper.be.tmpl.withoutNullOrBubble
@@ -24,6 +26,7 @@ import lang.temper.lexer.Genre
 import lang.temper.lexer.withTemperAwareExtension
 import lang.temper.library.LibraryConfigurations
 import lang.temper.log.FilePath
+import lang.temper.log.FilePathSegment
 import lang.temper.log.Position
 import lang.temper.log.dirPath
 import lang.temper.log.resolveFile
@@ -57,7 +60,6 @@ import lang.temper.type2.isVoidLike
 import lang.temper.type2.withNullity
 import lang.temper.type2.withType
 import lang.temper.value.DependencyCategory
-import lang.temper.value.MetadataValueMapHelpers.get
 import lang.temper.value.TBoolean
 import lang.temper.value.TClass
 import lang.temper.value.TClosureRecord
@@ -77,6 +79,7 @@ import lang.temper.value.TSymbol
 import lang.temper.value.TType
 import lang.temper.value.TVoid
 import lang.temper.value.YieldingFnKind
+import lang.temper.value.connectedSymbol
 import kotlin.math.abs
 
 /** Use a new translator for each temper module. */
@@ -113,6 +116,8 @@ internal class CSharpTranslator(
         fullNamespace = namespace
         qualifiedGlobalClassName = globalName
     }
+
+    private val connectedClassName = makeConnectedName(fullNamespace)
 
     private var imports: Map<ResolvedName, ExportedName> = module.imports.mapNotNull { imp ->
         imp.localName?.let { it.name to imp.externalName.name as ExportedName }
@@ -254,10 +259,7 @@ internal class CSharpTranslator(
         val modulePath = Backend.defaultFilePathForSource(
             libraryConfiguration, moduleName, "",
         )
-        val subspace = modulePath.segments.map { segment ->
-            segment.withTemperAwareExtension("").fullName.dashToPascal()
-        }
-        return subspace
+        return chooseSubspace(modulePath.segments)
     }
 
     private fun chooseVisibility(decl: TmpL.NameDeclaration) = when (decl.name.name) {
@@ -453,7 +455,11 @@ internal class CSharpTranslator(
             val result = translateType(decl.returnType)
             val (typeParameters, whereConstraints) = translateTypeParameters(decl.typeParameters)
             val parameters = translateParameters(decl.parameters)
-            var body = translateBlockStatement(decl.body, prelude = makeRestAssignment())
+            var body = when {
+                decl.metadata.any { it.key.symbol == connectedSymbol } && !module.isStdLib ->
+                    translateConnectedBody(decl, parameters) // TODO Rest param?
+                else -> translateBlockStatement(decl.body, prelude = makeRestAssignment())
+            }
 
             buildList {
                 if (!decl.mayYield) {
@@ -854,6 +860,40 @@ internal class CSharpTranslator(
             // This works because of how we generate labeled blocks. Goto is different than break.
             else -> CSharp.GotoStatement(statement.pos, translateId(label.id))
         }
+    }
+
+    private fun translateConnectedBody(
+        decl: TmpL.FunctionDeclaration,
+        parameters: List<CSharp.MethodParameter>,
+    ): CSharp.BlockStatement {
+        val pos = decl.pos
+        val defaulting = decl.parameterDefaultStatementsInfo()
+        return buildList {
+            for (statement in defaulting.defaultStatements) {
+                addAll(translateStatement(statement))
+            }
+            CSharp.InvocationExpression(
+                pos,
+                expr = CSharp.MemberAccess(
+                    pos,
+                    expr = connectedClassName.toIdentifier(pos) as CSharp.PrimaryExpression,
+                    id = translateId(decl.name, style = NameStyle.PrettyPascal),
+                ),
+                args = buildList {
+                    for ((tmpl, csharp) in decl.parameters.parameters.zip(parameters)) {
+                        when {
+                            tmpl.optional -> translateName(pos, defaulting.parameterMapping.getValue(tmpl.name.name))
+                            else -> csharp.name.deepCopy()
+                        }.also { add(it) }
+                    }
+                },
+            ).also { call ->
+                when {
+                    decl.returnType.isVoidish() -> CSharp.ExpressionStatement(pos, call)
+                    else -> CSharp.ReturnStatement(pos, call)
+                }.also { add(it) }
+            }
+        }.let { CSharp.BlockStatement(pos, it) }
     }
 
     private fun translateContinueStatement(statement: TmpL.ContinueStatement): CSharp.Statement {
@@ -2445,6 +2485,7 @@ private fun makeGarbageExpression(pos: Position, text: String?) = CSharp.Invocat
     args = text?.let { listOf(CSharp.StringLiteral(pos, text)) } ?: listOf(),
 )
 
+internal fun makeConnectedName(fullNamespace: QualifiedName) = "${fullNamespace.last()}Connected"
 internal fun makeGlobalName(fullNamespace: QualifiedName) = "${fullNamespace.last()}Global"
 
 /** This is awkward, but it centralizes common logic that's used in two places. Maybe reorg code better sometime. */
@@ -2491,6 +2532,13 @@ internal fun Type2.isOptionalTypeArg(): Boolean {
     val sawTypeFormal = this is TypeParamRef &&
         !excludeTypeFormalFromOptionalTransform(this.definition)
     return sawNull && sawTypeFormal
+}
+
+/** "foo-bar/baz/" -> ["FooBar", "Baz"] */
+internal fun chooseSubspace(segments: List<FilePathSegment>): List<String> {
+    return segments.map { segment ->
+        segment.withTemperAwareExtension("").fullName.dashToPascal()
+    }
 }
 
 private fun excludeTypeFormalFromOptionalTransform(typeFormal: TypeFormal): Boolean {

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/Lua.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/Lua.kt
@@ -723,6 +723,41 @@ object Lua {
         }
     }
 
+    /**
+     * For embedding external raw `@connected` Lua source. Should be placed after
+     * predeclarations and before other top-level statements.
+     */
+    class Connected(
+        pos: Position,
+        var source: String,
+    ) : BaseTree(pos), Stmt {
+        override val operatorDefinition: LuaOperatorDefinition?
+            get() = null
+        override fun renderTo(
+            tokenSink: TokenSink,
+        ) {
+            tokenSink.value(source)
+        }
+        override val codeFormattingTemplate: CodeFormattingTemplate?
+            get() = null
+        override fun deepCopy(): Connected {
+            return Connected(pos, source = this.source)
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is Connected && this.source == other.source
+        }
+        override fun hashCode(): Int {
+            return source.hashCode()
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships()
+        }
+    }
+
     class ReturnStmt(
         pos: Position,
         exprs: Exprs,

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaBackend.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaBackend.kt
@@ -14,6 +14,7 @@ import lang.temper.common.MimeType
 import lang.temper.common.currents.SignalRFuture
 import lang.temper.common.ignore
 import lang.temper.common.isNotEmpty
+import lang.temper.common.subListToEnd
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
 import lang.temper.fs.loadResource
@@ -26,6 +27,7 @@ import lang.temper.library.license
 import lang.temper.library.version
 import lang.temper.log.FilePath
 import lang.temper.log.FilePathSegment
+import lang.temper.log.asFilePath
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
@@ -80,12 +82,29 @@ class LuaBackend private constructor(
         val luaLibraryName = libraryConfigurations.currentLibraryConfiguration.libraryName.text
 
         val translations = finished.modules.flatMap { mod ->
+            val connectedPath = mod.codeLocation.codeLocation.sourceFile.resolveFile("_connected.lua")
             val translator = LuaTranslator(
                 luaNames,
                 luaLibraryName = luaLibraryName,
                 dependenciesBuilder = dependenciesBuilder,
+                connectedSource = rawBackendFiles[connectedPath],
             )
             translator.translateTopLevel(mod)
+        }
+
+        val connectedFiles = buildList {
+            rawBackendFiles@ for (file in rawBackendFiles) {
+                // Special _connected.lua file gets inlined.
+                file.key.last().fullName == "_connected.lua" && continue@rawBackendFiles
+                // Others get copied.
+                // TODO Make sure things get into good places.
+                MetadataFileSpecification(
+                    // Skip the library name part.
+                    path = file.key.segments.subListToEnd(1).asFilePath(),
+                    mimeType = MimeType.luaSource,
+                    content = file.value,
+                ).also { add(it) }
+            }
         }
 
         val initPath = filePath(INIT_NAME)
@@ -127,7 +146,7 @@ class LuaBackend private constructor(
             LuaMetadataKey.MainFilePath,
             FilePath(listOf(FilePathSegment(luaLibraryName)), isDir = true) + initPath,
         )
-        return translations + metadataFiles
+        return translations + connectedFiles + metadataFiles
     }
 
     private fun makeRockspec(

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaClosure.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaClosure.kt
@@ -221,6 +221,7 @@ class LuaClosure(val objName: LuaName, val importedNames: List<LuaName>) {
     private fun scan(stmt: Lua.LastStmt?): Lua.LastStmt? = stmt
 
     internal fun scan(stmt: Lua.Stmt): Lua.Stmt = when (stmt) {
+        is Lua.Connected -> stmt
         is Lua.LastStmt -> stmt
         is Lua.CallStmt -> Lua.CallStmt(
             stmt.pos,

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaFormattingHints.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaFormattingHints.kt
@@ -3,6 +3,7 @@ package lang.temper.be.lua
 import lang.temper.common.TriState
 import lang.temper.format.FormattingHints
 import lang.temper.format.OutputToken
+import lang.temper.format.OutputTokenType
 
 internal class LuaFormattingHints : FormattingHints {
     companion object {
@@ -31,6 +32,9 @@ internal class LuaFormattingHints : FormattingHints {
             return false
         }
         if (noSpace.matches(preceding.text) || noSpace.matches(following.text)) {
+            return false
+        }
+        if (preceding.type == OutputTokenType.OtherValue) {
             return false
         }
         return super.spaceBetween(preceding, following)

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaHelpers.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaHelpers.kt
@@ -144,6 +144,7 @@ internal fun copyTree(tree: Lua.Params): Lua.Params = Lua.Params(
 )
 
 internal fun copyTree(tree: Lua.Stmt): Lua.Stmt = when (tree) {
+    is Lua.Connected -> tree.deepCopy()
     is Lua.GotoStmt -> Lua.GotoStmt(
         tree.pos,
         copyTree(tree.name) as Lua.Name,

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaLocalCounter.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaLocalCounter.kt
@@ -108,6 +108,7 @@ class LuaLocalCounter(val cb: (Int) -> Unit) {
     }
 
     private fun countLocalsBy(stmt: Lua.Stmt): Int = when (stmt) {
+        is Lua.Connected -> 1 // Require all in one local.
         is Lua.GotoStmt -> 0
         is Lua.LocalStmt -> stmt.targets.targets.size
         is Lua.LocalDeclStmt -> stmt.targets.targets.size

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaLocalRemover.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaLocalRemover.kt
@@ -285,6 +285,7 @@ class LuaLocalRemover {
     }
 
     internal fun scan(stmt: Lua.Stmt): Lua.Stmt? = when (stmt) {
+        is Lua.Connected -> stmt.deepCopy() // TODO Anything we can/should do here?
         is Lua.GotoStmt -> Lua.GotoStmt(
             stmt.pos,
             Lua.Name(stmt.name.pos, stmt.name.id),

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaSupportNetwork.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaSupportNetwork.kt
@@ -526,18 +526,21 @@ internal object LuaSupportNetwork : SupportNetwork {
         "core.type StringIndexOption.compareTo()::ge" ->
             inlineBinaryOp(connectedKey, BinaryOpEnum.GtEq, LuaOperatorDefinition.Ge)
 
-        else -> temperMethod(
-            connectedKey,
-            connectedKey
-                .split(".", "::")
-                // Skip module name.
-                .subListToEnd(1)
-                .joinToString("_") { part ->
-                    // Skip qualifiers and parens.
-                    part.split(" ").last().trimEnd('(', ')')
-                }
-                .lowercase(),
-        )
+        else if connectedKey.startsWith("core.") || connectedKey.startsWith("std/") ->
+            temperMethod(
+                connectedKey,
+                connectedKey
+                    .split(".", "::")
+                    // Skip module name.
+                    .subListToEnd(1)
+                    .joinToString("_") { part ->
+                        // Skip qualifiers and parens.
+                        part.split(" ").last().trimEnd('(', ')')
+                    }
+                    .lowercase(),
+            )
+
+        else -> null
     }
 
     override fun translatedConnectedType(
@@ -577,6 +580,12 @@ internal data class InlineLua(
     override val builtinOperatorId: BuiltinOperatorId? = null,
     val factory: (pos: Position, arguments: List<Lua.Expr>) -> Lua.Tree,
 ) : InlineSupportCode<Lua.Tree, LuaTranslator>, NamedSupportCode {
+
+    init {
+        if ("prod" in name) {
+            name.length
+        }
+    }
 
     override val baseName: ParsedName
         get() = ParsedName(name)

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaSupportNetwork.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaSupportNetwork.kt
@@ -581,12 +581,6 @@ internal data class InlineLua(
     val factory: (pos: Position, arguments: List<Lua.Expr>) -> Lua.Tree,
 ) : InlineSupportCode<Lua.Tree, LuaTranslator>, NamedSupportCode {
 
-    init {
-        if ("prod" in name) {
-            name.length
-        }
-    }
-
     override val baseName: ParsedName
         get() = ParsedName(name)
 

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
@@ -8,7 +8,9 @@ import lang.temper.be.tmpl.TmpLOperator
 import lang.temper.be.tmpl.canBeNull
 import lang.temper.be.tmpl.dependencyCategory
 import lang.temper.be.tmpl.implicitTypeTag
+import lang.temper.be.tmpl.isStdLib
 import lang.temper.be.tmpl.libraryName
+import lang.temper.be.tmpl.parameterDefaultStatementsInfo
 import lang.temper.be.tmpl.withoutBubbleOrNull
 import lang.temper.common.MimeType
 import lang.temper.common.ParseDouble
@@ -24,8 +26,10 @@ import lang.temper.log.last
 import lang.temper.log.spanningPosition
 import lang.temper.name.DashedIdentifier
 import lang.temper.name.ExportedName
+import lang.temper.name.ResolvedParsedName
 import lang.temper.type.MethodKind
 import lang.temper.type.MethodShape
+import lang.temper.type.WellKnownTypes
 import lang.temper.value.DependencyCategory
 import lang.temper.value.TBoolean
 import lang.temper.value.TClass
@@ -45,6 +49,7 @@ import lang.temper.value.TString
 import lang.temper.value.TSymbol
 import lang.temper.value.TType
 import lang.temper.value.TVoid
+import lang.temper.value.connectedSymbol
 
 internal class LuaTranslator(
     val luaNames: LuaNames,
@@ -52,13 +57,25 @@ internal class LuaTranslator(
     val luaLibraryName: String? = null,
     private val shouldWrapFuncs: Boolean = false,
     private val dependenciesBuilder: Dependencies.Builder<LuaBackend>? = null,
+    private val connectedSource: String? = null,
 ) {
     fun translateTopLevel(mod: TmpL.Module): List<Backend.TranslatedFileSpecification> = luaNames.forModule(
         mod.codeLocation.codeLocation,
     ) {
         // Set up.
         fun makeParts(dependencyCategory: DependencyCategory) =
-            ModuleParts(dependencyCategory, luaNames, luaClosureMode, shouldWrapFuncs, dependenciesBuilder)
+            ModuleParts(
+                mod,
+                dependencyCategory,
+                luaNames,
+                luaClosureMode,
+                shouldWrapFuncs,
+                dependenciesBuilder,
+                connectedSource = when (dependencyCategory) {
+                    DependencyCategory.Production -> connectedSource
+                    DependencyCategory.Test -> null // TODO Connected source for test.
+                },
+            )
         val prodModuleParts = makeParts(DependencyCategory.Production)
         val testModuleParts = makeParts(DependencyCategory.Test)
         prodModuleParts.init(mod)
@@ -139,11 +156,13 @@ internal class LuaTranslator(
 }
 
 private class ModuleParts(
+    val mod: TmpL.Module,
     val dependencyCategory: DependencyCategory,
     val luaNames: LuaNames,
     val luaClosureMode: LuaClosureMode = LuaClosureMode.BasicFunction,
     private val shouldWrapFuncs: Boolean = false,
     private val dependenciesBuilder: Dependencies.Builder<LuaBackend>? = null,
+    private val connectedSource: String? = null,
 ) {
     private var breaks = mutableListOf<String?>()
     private var continues = mutableListOf<String?>()
@@ -1786,11 +1805,15 @@ private class ModuleParts(
             stmt.parameters.pos,
             translateParamDecl(stmt.parameters),
         )
-        val body = luaChunk(
-            stmt.body.pos,
-            handleSpecialParams(stmt.parameters) + translateStmt(stmt.body),
-            null,
-        )
+        val body = when {
+            stmt.metadata.any { it.key.symbol == connectedSymbol } && !mod.isStdLib ->
+                translateConnectedBody(stmt, params)
+            else -> luaChunk(
+                stmt.body.pos,
+                handleSpecialParams(stmt.parameters) + translateStmt(stmt.body),
+                null,
+            )
+        }
         var funcExpr: Lua.Expr = Lua.FunctionExpr(pos, params, body)
         if (stmt.mayYield) {
             // Make it a coroutine
@@ -1829,6 +1852,47 @@ private class ModuleParts(
                 ),
             ),
         )
+    }
+
+    private fun translateConnectedBody(
+        stmt: TmpL.ModuleFunctionDeclaration,
+        params: Lua.Params,
+    ): Lua.Chunk {
+        val pos = stmt.pos
+        val defaulting = stmt.parameterDefaultStatementsInfo()
+        var last: Lua.LastStmt? = null
+        val body = buildList {
+            addAll(handleSpecialParams(stmt.parameters))
+            for (statement in defaulting.defaultStatements) {
+                addAll(translateStmt(statement))
+            }
+            when (val name = stmt.name.name) {
+                // Avoid suffices even for ParsedName instances here.
+                is ResolvedParsedName -> name.baseName.nameText
+                else -> name.displayName
+            }.let { "_connected".asName(pos).dot(it) }.call(
+                buildList {
+                    for ((tmpl, lua) in stmt.parameters.parameters.zip(params.params)) {
+                        when {
+                            tmpl.optional -> {
+                                val name = defaulting.parameterMapping.getValue(tmpl.name.name)
+                                Lua.Name(pos, luaNames.name(name))
+                            }
+                            else -> when (lua) {
+                                is Lua.Param -> lua.name.deepCopy()
+                                is Lua.RestExpr -> lua.deepCopy() // TODO Good rest handling or frontend errors.
+                            }
+                        }.also { add(it) }
+                    }
+                }
+            ).also { call ->
+                when ((stmt.returnType.ot as? TmpL.NominalType)?.typeName?.sourceDefinition) {
+                    WellKnownTypes.voidTypeDefinition -> add(Lua.CallStmt(pos, call))
+                    else -> last = Lua.ReturnStmt(pos, Lua.Exprs(pos, listOf(call)))
+                }
+            }
+        }
+        return Lua.Chunk(stmt.pos, body, last)
     }
 
     private fun translateTopLevel(
@@ -2453,6 +2517,9 @@ private class ModuleParts(
             buildList {
                 addAll(imports)
                 addAll(preDecls)
+                if (connectedSource != null) {
+                    add(Lua.Connected(pos, connectedSource))
+                }
                 addAll(globalFuncs)
                 addAll(topLevels)
                 addAll(exports)

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
@@ -1884,7 +1884,7 @@ private class ModuleParts(
                             }
                         }.also { add(it) }
                     }
-                }
+                },
             ).also { call ->
                 when ((stmt.returnType.ot as? TmpL.NominalType)?.typeName?.sourceDefinition) {
                     WellKnownTypes.voidTypeDefinition -> add(Lua.CallStmt(pos, call))

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/lua.out-grammar
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/lua.out-grammar
@@ -9,8 +9,15 @@ Program = Chunk;
 
 Chunk ::= body%Stmt*"" & last%LastStmt?;
 
-Stmt = LabelStmt | DoStmt | WhileStmt | IfStmt | SetStmt | FunctionStmt | LocalDeclStmt | LocalStmt | LocalFunctionStmt | CallStmt | Comment | GotoStmt;
+Stmt = LabelStmt | DoStmt | WhileStmt | IfStmt | SetStmt | FunctionStmt | LocalDeclStmt | LocalStmt | LocalFunctionStmt | CallStmt | Comment | GotoStmt | Connected;
 LastStmt = ReturnStmt | BreakStmt | GotoStmt;
+
+/**
+ * For embedding external raw `@connected` Lua source. Should be placed after
+ * predeclarations and before other top-level statements.
+ */
+Connected(source%`String`);
+Connected.renderTo = `tokenSink.value(source)`;
 
 CallStmt ::= callExpr%CallExpr & ";";
 CallExpr = MethodCallExpr | FunctionCallExpr;

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/Py.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/Py.kt
@@ -54,6 +54,7 @@ object Py {
 
     class Program(
         pos: Position,
+        connected: Connected? = null,
         body: Iterable<Stmt>,
         var dependencyCategory: DependencyCategory,
         var genre: Genre,
@@ -64,43 +65,83 @@ object Py {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() = sharedCodeFormattingTemplate0
         override val formatElementCount
-            get() = 1
+            get() = 2
         override fun formatElement(
             index: Int,
         ): IndexableFormattableTreeElement {
             return when (index) {
-                0 -> FormattableTreeGroup(this.body)
+                0 -> this.connected ?: FormattableTreeGroup.empty
+                1 -> FormattableTreeGroup(this.body)
                 else -> throw IndexOutOfBoundsException("$index")
             }
         }
+        private var _connected: Connected?
+        var connected: Connected?
+            get() = _connected
+            set(newValue) { _connected = updateTreeConnection(_connected, newValue) }
         private val _body: MutableList<Stmt> = mutableListOf()
         var body: List<Stmt>
             get() = _body
             set(newValue) { updateTreeConnections(_body, newValue) }
         override fun deepCopy(): Program {
-            return Program(pos, body = this.body.deepCopy(), dependencyCategory = this.dependencyCategory, genre = this.genre, outputPath = this.outputPath)
+            return Program(pos, connected = this.connected?.deepCopy(), body = this.body.deepCopy(), dependencyCategory = this.dependencyCategory, genre = this.genre, outputPath = this.outputPath)
         }
         override val childMemberRelationships
             get() = cmr
         override fun equals(
             other: Any?,
         ): Boolean {
-            return other is Program && this.body == other.body && this.dependencyCategory == other.dependencyCategory && this.genre == other.genre && this.outputPath == other.outputPath
+            return other is Program && this.connected == other.connected && this.body == other.body && this.dependencyCategory == other.dependencyCategory && this.genre == other.genre && this.outputPath == other.outputPath
         }
         override fun hashCode(): Int {
-            var hc = body.hashCode()
+            var hc = (connected?.hashCode() ?: 0)
+            hc = 31 * hc + body.hashCode()
             hc = 31 * hc + dependencyCategory.hashCode()
             hc = 31 * hc + genre.hashCode()
             hc = 31 * hc + outputPath.hashCode()
             return hc
         }
         init {
+            this._connected = updateTreeConnection(null, connected)
             updateTreeConnections(this._body, body)
         }
         companion object {
             private val cmr = ChildMemberRelationships(
+                { n -> (n as Program).connected },
                 { n -> (n as Program).body },
             )
+        }
+    }
+
+    /** For embedding external raw `@connected` Python source. */
+    class Connected(
+        pos: Position,
+        var source: String,
+    ) : BaseTree(pos) {
+        override val operatorDefinition: PyOperatorDefinition?
+            get() = null
+        override fun renderTo(
+            tokenSink: TokenSink,
+        ) {
+            tokenSink.value(source)
+        }
+        override val codeFormattingTemplate: CodeFormattingTemplate?
+            get() = null
+        override fun deepCopy(): Connected {
+            return Connected(pos, source = this.source)
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is Connected && this.source == other.source
+        }
+        override fun hashCode(): Int {
+            return source.hashCode()
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships()
         }
     }
 
@@ -1450,38 +1491,6 @@ object Py {
         init {
             // No newlines in line comments.
             require(!pyLineTerminator.matches(commentText)) { commentText }
-        }
-        companion object {
-            private val cmr = ChildMemberRelationships()
-        }
-    }
-
-    /** Used for embedding external raw Python source. */
-    class Raw(
-        pos: Position,
-        var source: String,
-    ) : BaseTree(pos), Stmt {
-        override val operatorDefinition: PyOperatorDefinition?
-            get() = null
-        override fun renderTo(
-            tokenSink: TokenSink,
-        ) {
-            tokenSink.value(source)
-        }
-        override val codeFormattingTemplate: CodeFormattingTemplate?
-            get() = null
-        override fun deepCopy(): Raw {
-            return Raw(pos, source = this.source)
-        }
-        override val childMemberRelationships
-            get() = cmr
-        override fun equals(
-            other: Any?,
-        ): Boolean {
-            return other is Raw && this.source == other.source
-        }
-        override fun hashCode(): Int {
-            return source.hashCode()
         }
         companion object {
             private val cmr = ChildMemberRelationships()
@@ -3801,11 +3810,16 @@ object Py {
         }
     }
 
-    /** `{{0*}}` */
+    /** `{{0}} {{1*}}` */
     private val sharedCodeFormattingTemplate0 =
-        CodeFormattingTemplate.GroupSubstitution(
-            0,
-            CodeFormattingTemplate.empty,
+        CodeFormattingTemplate.Concatenation(
+            listOf(
+                CodeFormattingTemplate.OneSubstitution(0),
+                CodeFormattingTemplate.GroupSubstitution(
+                    1,
+                    CodeFormattingTemplate.empty,
+                ),
+            ),
         )
 
     /** `{{0*}} async def {{1}} ( {{2}} ) -> {{3}} : \n `SpecialTokens.indent` {{4*}} pass \n `SpecialTokens.dedent`` */

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyAst.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyAst.kt
@@ -151,9 +151,9 @@ fun garbageStmt(pos: Position, d: TmpL.Diagnostic?): Py.Stmt = garbageStmt(pos, 
 fun Py.Program?.orEmpty(outputPath: FilePath): Py.Program =
     this ?: Py.Program(
         unknownPos,
-        listOf(),
-        DependencyCategory.Production,
-        Genre.Library,
+        body = listOf(),
+        dependencyCategory = DependencyCategory.Production,
+        genre = Genre.Library,
         outputPath = outputPath,
     )
 

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyNames.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyNames.kt
@@ -175,10 +175,9 @@ class PyNames(visit: LookupNameVisitor?, private val abbreviated: Boolean = fals
         return OutName(safeName, sourceName = name)
     }
 
-    /** Supports simple `_whatever` naming until we can arrange it more generally on names. */
-    fun choosePrettyPrivateSourceName(name: ResolvedParsedName, kind: TmpL.IdKind): String {
-        val styledName = styleName(safeIdent(name.baseName.nameText), kind)
-        return "_$styledName"
+    /** Provide a pretty name, whether exported or not. */
+    fun choosePrettyName(name: ResolvedParsedName, kind: TmpL.IdKind): String {
+        return avoidReserved(styleName(safeIdent(name.baseName.nameText), kind))
     }
 
     private fun styleName(

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
@@ -1149,9 +1149,6 @@ class PyTranslator(
         args: Py.Arguments,
     ): List<Py.Stmt> {
         // Call the connected function, after substituting any default arg values.
-        // Use a pretty but private name for the connected function.
-        val name = func.name.name as ResolvedParsedName
-        val nameText = pyNames.choosePrettyPrivateSourceName(name, TmpL.IdKind.Value)
         return buildList {
             addAll(renames)
             val defaulting = func.parameterDefaultStatementsInfo()
@@ -1160,7 +1157,8 @@ class PyTranslator(
                 addAll(translate(statement))
             }
             // Call the connected function with defaults applied.
-            Py.Name(func.pos, PyIdentifierName(nameText)).call(
+            Py.Name(func.pos, PyIdentifierName("_connected")).method(
+                name = pyNames.choosePrettyName(func.name.name as ResolvedParsedName, TmpL.IdKind.Value),
                 args = buildList {
                     for ((tmpl, py) in func.parameters.parameters.zip(args.args)) {
                         when {

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyTranslator.kt
@@ -132,7 +132,6 @@ class PyTranslator(
         val tests = mutableListOf<Py.Stmt>()
         val ungroupedImports = mutableListOf<Py.ImportFrom>()
         translateImports(t.imports, ungroupedImports)
-        connectedSource?.also { result.add(Py.Raw(t.pos, it)) }
         t.topLevels.forEach {
             at(it) topLevel@{
                 val dependencyCategory = it.dependencyCategory() ?: return@topLevel
@@ -178,10 +177,11 @@ class PyTranslator(
                 add(
                     Py.Program(
                         t.pos,
-                        result,
-                        DependencyCategory.Production,
-                        defaultGenre,
-                        t.codeLocation.outputPath,
+                        connected = connectedSource?.let { Py.Connected(t.pos, it) },
+                        body = result,
+                        dependencyCategory = DependencyCategory.Production,
+                        genre = defaultGenre,
+                        outputPath = t.codeLocation.outputPath,
                     ),
                 )
             }
@@ -190,10 +190,10 @@ class PyTranslator(
                 add(
                     Py.Program(
                         t.pos,
-                        tests,
-                        DependencyCategory.Test,
-                        Genre.Library,
-                        convertToTestPath(t.codeLocation.outputPath),
+                        body = tests,
+                        dependencyCategory = DependencyCategory.Test,
+                        genre = Genre.Library,
+                        outputPath = convertToTestPath(t.codeLocation.outputPath),
                     ),
                 )
             }

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/py.out-grammar
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/py.out-grammar
@@ -22,12 +22,20 @@ let imports = """
   "lang.temper.value.DependencyCategory
 ;
 
-Program ::= body%Stmt*"";
+Program ::=
+      // Limit connected scope to top of file for avoiding abuse.
+      connected%Connected?
+    & body%Stmt*"";
 Program(
     dependencyCategory%`DependencyCategory`,
     genre%`Genre`,
     outputPath%`FilePath`,
 );
+Program.connected.default = `null`;
+
+/** For embedding external raw `@connected` Python source. */
+Connected(source%`String`);
+Connected.renderTo = `tokenSink.value(source)`;
 
 Stmt =
       FunctionDef
@@ -54,8 +62,7 @@ Stmt =
     | Pass
     | Break
     | Continue
-    | CommentLine
-    | Raw;
+    | CommentLine;
 
 /**
  * decorator: `'@' dotted_name [ '(' [args] ')' ] NEWLINE`
@@ -540,7 +547,3 @@ BinaryOp.operatorDefinition = `null`;
 UnaryOp(opEnum%`UnaryOpEnum`, expressionOperatorDefinition%`PyOperatorDefinition`);
 UnaryOp.renderTo = `opEnum.renderTo(tokenSink)`;
 UnaryOp.operatorDefinition = `null`;
-
-/** Used for embedding external raw Python source. */
-Raw(source%`String`);
-Raw.renderTo = `tokenSink.value(source)`;

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
@@ -14,7 +14,6 @@ import lang.temper.frontend.Module
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
 import lang.temper.interp.importExport.STANDARD_LIBRARY_NAME
-import lang.temper.library.LibraryConfiguration
 import lang.temper.library.authors
 import lang.temper.library.description
 import lang.temper.library.homepage
@@ -27,6 +26,7 @@ import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
 import lang.temper.log.resolveDir
+import lang.temper.log.resolveFile
 import lang.temper.name.BackendId
 import lang.temper.name.BackendMeta
 import lang.temper.name.DashedIdentifier
@@ -85,12 +85,17 @@ class RustBackend(setup: BackendSetup<RustBackend>) : Backend<RustBackend>(Facto
             val deps = mutableSetOf<Dep>()
             val featuresByDep = mutableMapOf<String, MutableSet<String>>()
             val modNames = mutableListOf<String>()
+            var rootModKids: Collection<FilePath> = allModKids[libraryConfiguration.libraryRoot] ?: listOf()
             for (module in modules) {
                 // Actually translate.
                 val modKids = allModKids[module.codeLocation.codeLocation.sourceFile] ?: listOf()
                 val translator = RustTranslator(dependenciesBuilder, module, names, modKids)
                 val mod = translator.translateModule()
                 add(mod)
+                // Track root mod kids, including possible connected.
+                if (translator.isRoot) {
+                    rootModKids = translator.allModKids()
+                }
                 // We slap mod.rs on the end of each, so exclude that.
                 val segments = mod.path.dirName().segments
                 val pathed = segments.subListToEnd(1).joinToString("::") { it.fullName.escapeIfNeeded() }
@@ -122,9 +127,23 @@ class RustBackend(setup: BackendSetup<RustBackend>) : Backend<RustBackend>(Facto
                     ).let { deps.add(it) }
                 }
             }
+            // Copy connected code.
+            for (file in rawBackendFiles) {
+                // Put rust connected modules into a subdir, under "src/" but skipping library name.
+                val connectedDir = file.key.dirName().resolveDir("_connected").segments.subListToEnd(1)
+                val fileName = when (val fileName = file.key.last().fullName) {
+                    "_connected.rs" -> "mod.rs"
+                    else -> fileName
+                }
+                MetadataFileSpecification(
+                    path = dirPath("src").resolve(connectedDir, isDir = true).resolveFile(fileName),
+                    mimeType = mimeType,
+                    content = file.value,
+                ).also { add(it) }
+            }
             // Merge lib. TODO Can we sort init in dependency order? Do we need to? Dep order maybe not hierarchical?
             linkLayers(finished.pos, allModPaths, allModKids)
-            addLib(finished.pos, modules, allModKids, deps, libraryConfiguration, modNames)
+            addLib(finished.pos, modules, rootModKids, deps, modNames)
             // Main program.
             MetadataFileSpecification(
                 path = filePath("src", "main.rs"),
@@ -302,9 +321,8 @@ private fun ResourceDescriptor.mimeType() = rsrcPath.mimeType()
 private fun MutableList<Backend.OutputFileSpecification>.addLib(
     pos: Position,
     modules: List<TmpL.Module>,
-    allModKids: Map<FilePath, Set<FilePath>>,
+    modKids: Collection<FilePath>,
     deps: Set<Dep>,
-    libraryConfiguration: LibraryConfiguration,
     modNames: List<String>,
 ) {
     val hasTopLevel = modules.any { it.codeLocation.codeLocation.relativePath().segments.isEmpty() }
@@ -315,7 +333,7 @@ private fun MutableList<Backend.OutputFileSpecification>.addLib(
             attrs = allowWarnings(pos),
             items = buildList {
                 // Separate mods.
-                declareSubmods(pos, allModKids[libraryConfiguration.libraryRoot] ?: setOf())
+                declareSubmods(pos, modKids)
                 // Top mod.
                 val pub = Rust.VisibilityPub(pos)
                 if (hasTopLevel) {

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustExt.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustExt.kt
@@ -81,8 +81,18 @@ internal fun whereForAnyValueImpl(pos: Position, translatedGenerics: List<Rust.G
 
 internal fun MutableList<Rust.Item>.declareSubmods(pos: Position, modKids: Collection<FilePath>) {
     for (kid in modKids) {
-        val modId = kid.last().temperAwareBaseName().dashToSnake().toId(pos)
-        add(Rust.Module(pos, id = modId, pub = Rust.VisibilityPub(pos)).toItem())
+        val (modId, pub) = kid.last().temperAwareBaseName().let { name ->
+            // This is a hacky workaround to recognize our "_connected" convention.
+            // But at least it does distinguish something that's already snake case.
+            // The main problem with this convention is that leading underscore typically
+            // means unused in Rust rather than private, but it still works.
+            // TODO Just say "connected" and recognize that here explicitly for non-pub?
+            when {
+                name.startsWith("_") -> name.toId(pos) to null
+                else -> name.dashToSnake().toId(pos) to Rust.VisibilityPub(pos)
+            }
+        }
+        add(Rust.Module(pos, id = modId, pub = pub).toItem())
     }
 }
 
@@ -369,11 +379,26 @@ internal fun Rust.Expr.wrapOkOrElse(pos: Position = this.pos) =
 
 internal fun Rust.Expr.wrapSome() = Rust.Call(pos, callee = "Some".toId(pos), args = listOf(this))
 
-/** Only handles cases where the pattern is a [Rust.Id]. */
-internal fun Rust.FunctionParamOption.toId(): Rust.Id {
+/**
+ * Only properly handles cases where the pattern is a [Rust.FunctionParam].
+ * Errors otherwise, unless [approximate], in which case, the id might be
+ * invalid.
+ */
+internal fun Rust.FunctionParamOption.toId(approximate: Boolean = false): Rust.Id {
     return when (this) {
         is Rust.FunctionParam -> this.pattern.deepCopy() as Rust.Id
-        is Rust.Id, is Rust.RefType -> error(this)
+        is Rust.Id, is Rust.RefType -> when {
+            approximate -> when (this) {
+                is Rust.Id -> this
+                is Rust.RefType -> when (val type = this.type) {
+                    is Rust.Id -> type
+                    // This is a total punt. Shouldn't get here on valid Temper code.
+                    else -> type.toString().toId(pos)
+                }
+                else -> error(this) // Can't actually happen, but Kotlin fails to realize.
+            }
+            else -> error(this)
+        }
     }
 }
 

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustTranslator.kt
@@ -12,10 +12,12 @@ import lang.temper.be.tmpl.TypedArg
 import lang.temper.be.tmpl.aType
 import lang.temper.be.tmpl.hasSplitSupers
 import lang.temper.be.tmpl.isNullValue
+import lang.temper.be.tmpl.isStdLib
 import lang.temper.be.tmpl.libraryName
 import lang.temper.be.tmpl.mapParameters
 import lang.temper.be.tmpl.mutableCaptures
 import lang.temper.be.tmpl.orInvalid
+import lang.temper.be.tmpl.parameterDefaultStatementsInfo
 import lang.temper.be.tmpl.referencedNames
 import lang.temper.be.tmpl.splitConstructorBody
 import lang.temper.be.tmpl.typeOrInvalid
@@ -30,6 +32,7 @@ import lang.temper.log.FilePath
 import lang.temper.log.LogSink
 import lang.temper.log.Position
 import lang.temper.log.last
+import lang.temper.log.resolveDir
 import lang.temper.name.BuiltinName
 import lang.temper.name.ExportedName
 import lang.temper.name.ImplicitsCodeLocation
@@ -80,6 +83,7 @@ import lang.temper.value.TString
 import lang.temper.value.TSymbol
 import lang.temper.value.TType
 import lang.temper.value.TVoid
+import lang.temper.value.connectedSymbol
 import lang.temper.value.failSymbol
 import lang.temper.value.sealedTypeSymbol
 
@@ -94,11 +98,13 @@ class RustTranslator(
         libraryConfigurations.currentLibraryConfiguration.libraryName,
         DescriptorsForDeclarations.Key(RustBackend.Factory),
     )?.nameToDescriptor ?: mapOf()
+    private var anyConnected = false
     private var closureCount = 0
     private val builderItems = mutableListOf<Rust.Item>()
     private val decls = mutableMapOf<ResolvedName, DeclInfo>()
     private val failVars = mutableSetOf<ResolvedName>()
     private var insideMutableType = false
+    internal val isRoot = module.codeLocation.codeLocation.relativePath().segments.isEmpty()
     private val functionContextStack = mutableListOf<FunctionContext>()
     private val logSink = LogSink.devNull // TODO what?
     private val loopLabels = mutableListOf<Rust.Id?>()
@@ -140,7 +146,6 @@ class RustTranslator(
         )
         // Build source file.
         val relPath = module.codeLocation.codeLocation.relativePath()
-        val isRoot = relPath.segments.isEmpty()
         return Backend.TranslatedFileSpecification(
             path = makeSrcFilePath(relPath.withTemperAwareExtension("")),
             content = Rust.SourceFile(
@@ -149,7 +154,7 @@ class RustTranslator(
                 items = buildList {
                     // Declare submodules, except for root that needs to declare in lib file.
                     if (!isRoot) {
-                        declareSubmods(pos, modKids)
+                        declareSubmods(pos, allModKids())
                     }
                     // Provide needed imports.
                     // We only need temper-core traits sometimes, but just keep simple for now.
@@ -205,6 +210,19 @@ class RustTranslator(
             ),
             mimeType = RustBackend.mimeType,
         )
+    }
+
+    /** Includes both those passed in and any that might need added from translation. */
+    internal fun allModKids(): Collection<FilePath> {
+        return when {
+            anyConnected -> buildList {
+                addAll(modKids)
+                // We track _connected here because of how we do lib/mod on root, and because
+                // we want to put the root connected files in an expected place.
+                add(module.codeLocation.codeLocation.relativePath().resolveDir("_connected"))
+            }
+            else -> modKids
+        }
     }
 
     private fun buildInit(): Rust.Block {
@@ -552,7 +570,12 @@ class RustTranslator(
     }
 
     private fun processModuleFunctionDeclaration(decl: TmpL.ModuleFunctionDeclaration) {
-        moduleItems.add(translateFunctionDeclarationOrMethod(decl))
+        val connectedBlock = when {
+            decl.metadata.any { it.key.symbol == connectedSymbol } && !module.isStdLib ->
+                translateConnectedBody(decl)
+            else -> null
+        }
+        moduleItems.add(translateFunctionDeclarationOrMethod(decl, block = connectedBlock))
     }
 
     private fun processModuleInitBlock(block: TmpL.ModuleInitBlock) {
@@ -1929,6 +1952,39 @@ class RustTranslator(
                     expr = translateBlock(elseCase.body),
                 ).also { add(it) }
             },
+        )
+    }
+
+    private fun translateConnectedBody(decl: TmpL.ModuleFunctionDeclaration): Rust.Block {
+        anyConnected = true
+        val pos = decl.pos
+        val defaulting = decl.parameterDefaultStatementsInfo()
+        return Rust.Block(
+            pos,
+            statements = buildList {
+                for (statement in defaulting.defaultStatements) {
+                    addAll(translateStatement(statement))
+                }
+            },
+            result = "_connected".toId(pos).let { connectedModule ->
+                when {
+                    isRoot -> "crate".toKeyId(pos).extendWith(connectedModule)
+                    else -> connectedModule
+                }
+            }.extendWith(translateId(decl.name, style = NameStyle.Snake)).call(
+                buildList {
+                    for ((tmpl, rust) in decl.parameters.parameters.zip(translateParameters(decl.parameters))) {
+                        when {
+                            tmpl.optional -> {
+                                val name = defaulting.parameterMapping.getValue(tmpl.name.name)
+                                translateIdFromName(pos, name)
+                            }
+                            // TODO Validate frontend cases that shouldn't get here.
+                            else -> rust.toId(approximate = true)
+                        }.also { add(it) }
+                    }
+                },
+            ),
         )
     }
 

--- a/functional-test-matrix.md
+++ b/functional-test-matrix.md
@@ -26,7 +26,7 @@
 | [ControlFlowLoopReenterable][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [ControlFlowLoops][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [FunctionsAsValues][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [FunctionsConnected][] | ❌<sup>[456][]</sup> | ❌<sup>[198][]</sup> | ❌<sup>[456][]</sup> | ❌<sup>[456][]</sup> | ✅ | ✅ | ❌<sup>[456][]</sup> | ❌<sup>[456][]</sup> | ✅ | ✅ | ❌<sup>[456][]</sup> |
+| [FunctionsConnected][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ❌<sup>[456][]</sup> | ✅ | ✅ | ❌<sup>[456][]</sup> | ✅ | ✅ | ✅ | ✅ |
 | [FunctionsConstructorCallbacks][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [FunctionsDefaulting][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [FunctionsLocals][] | ✅ | ❌<sup>[198][]</sup> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
+++ b/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
@@ -25,7 +25,7 @@ val functionalTestStatus: Map<Ft, List<IssueCheck>> = buildMap {
     issue(Ft.RegexZeroAdvance, lua(166))
     issue(Ft.NamesNonascii, lua(228))
     214.let { issue(Ft.TypesNetresponse, cpp(it), interp(it), lua(it)) }
-    456.let { issue(Ft.FunctionsConnected, interp(it), js(it), lua(it), rust(it)) }
+    456.let { issue(Ft.FunctionsConnected, interp(it), js(it), rust(it)) }
     onlyFails(
         cpp(198),
         Ft.RegexMatch,

--- a/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
+++ b/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
@@ -25,7 +25,7 @@ val functionalTestStatus: Map<Ft, List<IssueCheck>> = buildMap {
     issue(Ft.RegexZeroAdvance, lua(166))
     issue(Ft.NamesNonascii, lua(228))
     214.let { issue(Ft.TypesNetresponse, cpp(it), interp(it), lua(it)) }
-    456.let { issue(Ft.FunctionsConnected, cpp(it), csharp(it), interp(it), js(it), lua(it), rust(it)) }
+    456.let { issue(Ft.FunctionsConnected, cpp(it), interp(it), js(it), lua(it), rust(it)) }
     onlyFails(
         cpp(198),
         Ft.RegexMatch,

--- a/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
+++ b/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
@@ -25,7 +25,7 @@ val functionalTestStatus: Map<Ft, List<IssueCheck>> = buildMap {
     issue(Ft.RegexZeroAdvance, lua(166))
     issue(Ft.NamesNonascii, lua(228))
     214.let { issue(Ft.TypesNetresponse, cpp(it), interp(it), lua(it)) }
-    456.let { issue(Ft.FunctionsConnected, interp(it), js(it), rust(it)) }
+    456.let { issue(Ft.FunctionsConnected, interp(it), js(it)) }
     onlyFails(
         cpp(198),
         Ft.RegexMatch,

--- a/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
+++ b/functional-test-suite/src/commonMain/kotlin/lang/temper/tests/FunctionalTestStatus.kt
@@ -25,7 +25,7 @@ val functionalTestStatus: Map<Ft, List<IssueCheck>> = buildMap {
     issue(Ft.RegexZeroAdvance, lua(166))
     issue(Ft.NamesNonascii, lua(228))
     214.let { issue(Ft.TypesNetresponse, cpp(it), interp(it), lua(it)) }
-    456.let { issue(Ft.FunctionsConnected, cpp(it), interp(it), js(it), lua(it), rust(it)) }
+    456.let { issue(Ft.FunctionsConnected, interp(it), js(it), lua(it), rust(it)) }
     onlyFails(
         cpp(198),
         Ft.RegexMatch,

--- a/functional-test-suite/src/commonMain/resources/functions/connected/MoreSupport.cs
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/MoreSupport.cs
@@ -1,0 +1,12 @@
+namespace Work
+{
+    /// We automatically generate a Support subnamespace for Temper-built C#
+    /// libraries, so call this MoreSupport instead of just Support.
+    class MoreSupport
+    {
+        internal int Prod(int i, int j)
+        {
+            return i * j;
+        }
+    }
+}

--- a/functional-test-suite/src/commonMain/resources/functions/connected/WorkConnected.cs
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/WorkConnected.cs
@@ -1,0 +1,15 @@
+namespace Work
+{
+    static class WorkConnected
+    {
+        internal static int Sum(int i, int j, int bonus)
+        {
+            return i + j + bonus;
+        }
+
+        internal static int Prod(Hidden hidden, int j)
+        {
+            return new MoreSupport().Prod(hidden.I, j);
+        }
+    }
+}

--- a/functional-test-suite/src/commonMain/resources/functions/connected/__connected__.py
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/__connected__.py
@@ -1,8 +1,16 @@
-def _sum(i: int, j: int, bonus: int) -> int:
-    return i + j + bonus
-
-
-def _prod(hidden: "_Hidden", j: int) -> int:
+def _connected():
     from ._support import Support
 
-    return Support().prod(hidden.i, j)
+    def sum(i: int, j: int, bonus: int) -> int:
+        return i + j + bonus
+
+    def prod(hidden: "_Hidden", j: int) -> int:
+        return Support().prod(hidden.i, j)
+
+    global _sum, _prod
+    _sum = sum
+    _prod = prod
+
+
+_connected()
+del _connected

--- a/functional-test-suite/src/commonMain/resources/functions/connected/__connected__.py
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/__connected__.py
@@ -1,16 +1,8 @@
-def _connected():
+class _connected:
     from ._support import Support
 
     def sum(i: int, j: int, bonus: int) -> int:
         return i + j + bonus
 
     def prod(hidden: "_Hidden", j: int) -> int:
-        return Support().prod(hidden.i, j)
-
-    global _sum, _prod
-    _sum = sum
-    _prod = prod
-
-
-_connected()
-del _connected
+        return _connected.Support().prod(hidden.i, j)

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_connected.cpp
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_connected.cpp
@@ -1,0 +1,17 @@
+#include "_connected.hpp"
+#include "support.hpp"
+
+namespace work {
+namespace _connected {
+
+std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus) {
+    return i + j + bonus;
+}
+
+std::int32_t prod(std::shared_ptr<Hidden> const& hidden, std::int32_t j) {
+    Support support;
+    return support.prod(hidden->get_i(), j);
+}
+
+} // namespace _connected
+} // namespace work

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_connected.hpp
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_connected.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <work/init.hpp>
+
+namespace work {
+namespace _connected {
+
+using namespace work;
+
+std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus);
+
+std::int32_t prod(std::shared_ptr<Hidden> const& hidden, std::int32_t j);
+
+} // namespace _connected
+} // namespace work

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_connected.lua
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_connected.lua
@@ -1,0 +1,21 @@
+local _connected = {};
+
+do
+  local s = require("work._support")
+
+  ---@param i integer
+  ---@param j integer
+  ---@param bonus integer
+  ---@return integer
+  function _connected.sum(i, j, bonus)
+    return i + j + bonus
+  end
+
+  ---@param hidden work.Hidden TODO Actually define types in our Lua.
+  ---@param j integer
+  ---@return integer
+  function _connected.prod(hidden, j)
+    local support = s.Support.new()
+    return support:prod(hidden.i, j)
+  end
+end

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_connected.rs
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_connected.rs
@@ -1,0 +1,13 @@
+use super::Hidden;
+use more::Support;
+
+mod more;
+
+pub(crate) fn sum(i: i32, j: i32, bonus: i32) -> i32 {
+    i + j + bonus
+}
+
+pub(crate) fn prod(hidden: Hidden, j: i32) -> i32 {
+    let support = Support {};
+    support.prod(hidden.i(), j)
+}

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_support.lua
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_support.lua
@@ -1,0 +1,19 @@
+local exports = {}
+
+---@class Support
+local Support = {}
+Support.__index = Support
+exports.Support = Support
+
+function Support.new()
+    return setmetatable({}, Support)
+end
+
+---@param i integer
+---@param j integer
+---@return integer
+function Support:prod(i, j)
+    return i * j
+end
+
+return exports

--- a/functional-test-suite/src/commonMain/resources/functions/connected/more.rs
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/more.rs
@@ -1,0 +1,7 @@
+pub(crate) struct Support {}
+
+impl Support {
+    pub fn prod(&self, i: i32, j: i32) -> i32 {
+        i * j
+    }
+}

--- a/functional-test-suite/src/commonMain/resources/functions/connected/support.hpp
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/support.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <work/init.hpp>
+
+namespace work {
+
+class Support {
+public:
+    std::int32_t prod(std::int32_t i, std::int32_t j) {
+        return i * j;
+    }
+};
+
+} // namespace work

--- a/name/src/commonMain/kotlin/lang/temper/name/BackendId.kt
+++ b/name/src/commonMain/kotlin/lang/temper/name/BackendId.kt
@@ -85,6 +85,9 @@ enum class FileType {
 
     /** a script or application to run */
     Script,
+
+    /** a header file for pre-declarations */
+    Header,
 }
 
 /** Language labels may be equal to a backend's unique ID, unless multiple backends produce the same language */


### PR DESCRIPTION
- Pass connected functions funtest on all backends except interp and js
- Also refine be-py connecteds some
- To some extent, this is drafting the plan for userspace connecteds, maybe good approximately as is, but some forms of adjustment wouldn't be too hard
- Js is hard because standard import is only top level and our "whatever.internal.js" handling is still awkward
- Interp needs some way for backends to know when to use temper impl vs connected code