### PR TITLE
be-rust: Require parens for as inside cmp

### DIFF
--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustOperatorDefinition.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustOperatorDefinition.kt
@@ -28,6 +28,7 @@ enum class RustOperatorDefinition(
     // Copied from CSharpOperatorDefinition.
     override fun canNest(inner: OperatorDefinition, childIndex: Int) = when {
         inner !is RustOperatorDefinition -> false
+        this == Relational && inner == As -> false // `as T < ...` interpreted as generic arguments
         ordinal < inner.ordinal -> true
         ordinal > inner.ordinal -> false
         // TODO Does this allow `==` to nest?

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -2831,7 +2831,7 @@ class RustBackendTest {
             |        let mut n__0: i32 = 0;
             |        let mut i__0: usize = start__0;
             |        'loop___0: loop {
-            |            if ! (Some(i__0).cmp( & Some(limit__0)) as i32 < 0) {
+            |            if ! ((Some(i__0).cmp( & Some(limit__0)) as i32) < 0) {
             |                break;
             |            }
             |            let cp__0: i32 = temper_core::string::get( & sourceText__0, i__0);
@@ -2890,7 +2890,7 @@ class RustBackendTest {
             |    }).clone()
             |}
             |pub fn not_empty(start__0: usize, limit__0: usize) -> bool {
-            |    return Some(start__0).cmp( & Some(limit__0)) as i32 < 0;
+            |    return (Some(start__0).cmp( & Some(limit__0)) as i32) < 0;
             |}
         """.trimMargin(),
     )


### PR DESCRIPTION
Address this error:

```rs
    --> C:\Users\work2\AppData\Local\Temp\temper-test3896171247360590248\rust\std\src\json\mod.rs:1782:64
     |
1782 |             if ! (Some(i__713).cmp( & Some(limit__710)) as i32 < 0) {
     |                                                                ^ -- interpreted as generic arguments
     |                                                                |
     |                                                                not interpreted as comparison
     |
help: try comparing the cast value
     |
1782 |             if ! ((Some(i__713).cmp( & Some(limit__710)) as i32) < 0) {
     |                   +                                            +
```