### PR TITLE
Support cross-backend adjustment

### DIFF
--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
@@ -740,7 +740,7 @@ object Cpp {
         pos: Position,
         var mod: DefMod? = null,
         type: Type,
-        name: Name,
+        name: VarDefNamePart,
         init: Expr?,
     ) : BaseTree(pos), Global, Stmt {
         override val operatorDefinition: CppOperatorDefinition?
@@ -769,8 +769,8 @@ object Cpp {
         var type: Type
             get() = _type
             set(newValue) { _type = updateTreeConnection(_type, newValue) }
-        private var _name: Name
-        var name: Name
+        private var _name: VarDefNamePart
+        var name: VarDefNamePart
             get() = _name
             set(newValue) { _name = updateTreeConnection(_name, newValue) }
         private var _init: Expr?
@@ -1271,6 +1271,10 @@ object Cpp {
         }
     }
 
+    sealed interface VarDefNamePart : Tree {
+        override fun deepCopy(): VarDefNamePart
+    }
+
     sealed interface Type : Tree {
         override fun deepCopy(): Type
     }
@@ -1279,7 +1283,7 @@ object Cpp {
         override fun deepCopy(): Expr
     }
 
-    sealed interface Name : Tree, Type, Expr {
+    sealed interface Name : Tree, VarDefNamePart, Type, Expr {
         override fun deepCopy(): Name
     }
 
@@ -1578,6 +1582,106 @@ object Cpp {
         }
     }
 
+    class ArrayVarDefDim(
+        pos: Position,
+        name: VarDefNamePart,
+        dim: LiteralExpr?,
+    ) : BaseTree(pos), VarDefNamePart {
+        override val operatorDefinition: CppOperatorDefinition?
+            get() = null
+        override val codeFormattingTemplate: CodeFormattingTemplate
+            get() = sharedCodeFormattingTemplate26
+        override val formatElementCount
+            get() = 2
+        override fun formatElement(
+            index: Int,
+        ): IndexableFormattableTreeElement {
+            return when (index) {
+                0 -> this.name
+                1 -> this.dim ?: FormattableTreeGroup.empty
+                else -> throw IndexOutOfBoundsException("$index")
+            }
+        }
+        private var _name: VarDefNamePart
+        var name: VarDefNamePart
+            get() = _name
+            set(newValue) { _name = updateTreeConnection(_name, newValue) }
+        private var _dim: LiteralExpr?
+        var dim: LiteralExpr?
+            get() = _dim
+            set(newValue) { _dim = updateTreeConnection(_dim, newValue) }
+        override fun deepCopy(): ArrayVarDefDim {
+            return ArrayVarDefDim(pos, name = this.name.deepCopy(), dim = this.dim?.deepCopy())
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is ArrayVarDefDim && this.name == other.name && this.dim == other.dim
+        }
+        override fun hashCode(): Int {
+            var hc = name.hashCode()
+            hc = 31 * hc + (dim?.hashCode() ?: 0)
+            return hc
+        }
+        init {
+            this._name = updateTreeConnection(null, name)
+            this._dim = updateTreeConnection(null, dim)
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships(
+                { n -> (n as ArrayVarDefDim).name },
+                { n -> (n as ArrayVarDefDim).dim },
+            )
+        }
+    }
+
+    class LiteralExpr(
+        pos: Position,
+        repr: Raw,
+    ) : BaseTree(pos), Expr {
+        override val operatorDefinition: CppOperatorDefinition?
+            get() = null
+        override val codeFormattingTemplate: CodeFormattingTemplate
+            get() = sharedCodeFormattingTemplate27
+        override val formatElementCount
+            get() = 1
+        override fun formatElement(
+            index: Int,
+        ): IndexableFormattableTreeElement {
+            return when (index) {
+                0 -> this.repr
+                else -> throw IndexOutOfBoundsException("$index")
+            }
+        }
+        private var _repr: Raw
+        var repr: Raw
+            get() = _repr
+            set(newValue) { _repr = updateTreeConnection(_repr, newValue) }
+        override fun deepCopy(): LiteralExpr {
+            return LiteralExpr(pos, repr = this.repr.deepCopy())
+        }
+        override val childMemberRelationships
+            get() = cmr
+        override fun equals(
+            other: Any?,
+        ): Boolean {
+            return other is LiteralExpr && this.repr == other.repr
+        }
+        override fun hashCode(): Int {
+            return repr.hashCode()
+        }
+        init {
+            this._repr = updateTreeConnection(null, repr)
+        }
+        companion object {
+            private val cmr = ChildMemberRelationships(
+                { n -> (n as LiteralExpr).repr },
+            )
+        }
+    }
+
     class PreComment(
         pos: Position,
         text: Raw,
@@ -1586,7 +1690,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate26
+            get() = sharedCodeFormattingTemplate28
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1641,7 +1745,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate27
+            get() = sharedCodeFormattingTemplate29
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1695,7 +1799,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate28
+            get() = sharedCodeFormattingTemplate30
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1740,7 +1844,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate29
+            get() = sharedCodeFormattingTemplate31
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1786,7 +1890,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate30
+            get() = sharedCodeFormattingTemplate32
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1840,7 +1944,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate31
+            get() = sharedCodeFormattingTemplate33
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1886,7 +1990,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate32
+            get() = sharedCodeFormattingTemplate34
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -1940,7 +2044,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate33
+            get() = sharedCodeFormattingTemplate35
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -1987,9 +2091,9 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() =
                 if (value != null) {
-                    sharedCodeFormattingTemplate34
+                    sharedCodeFormattingTemplate36
                 } else {
-                    sharedCodeFormattingTemplate35
+                    sharedCodeFormattingTemplate37
                 }
         override val formatElementCount
             get() = 1
@@ -2035,7 +2139,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate36
+            get() = sharedCodeFormattingTemplate38
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -2081,7 +2185,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate37
+            get() = sharedCodeFormattingTemplate39
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2134,7 +2238,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate38
+            get() = sharedCodeFormattingTemplate40
         override val formatElementCount
             get() = 0
         override fun deepCopy(): BreakStmt {
@@ -2164,7 +2268,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate39
+            get() = sharedCodeFormattingTemplate41
         override val formatElementCount
             get() = 3
         override fun formatElement(
@@ -2230,9 +2334,9 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() =
                 if (ifFalse != null) {
-                    sharedCodeFormattingTemplate40
+                    sharedCodeFormattingTemplate42
                 } else {
-                    sharedCodeFormattingTemplate41
+                    sharedCodeFormattingTemplate43
                 }
         override val formatElementCount
             get() = 3
@@ -2296,7 +2400,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate42
+            get() = sharedCodeFormattingTemplate44
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2351,7 +2455,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate43
+            get() = sharedCodeFormattingTemplate45
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2405,7 +2509,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate44
+            get() = sharedCodeFormattingTemplate46
         override val formatElementCount
             get() = 1
         override fun formatElement(
@@ -2451,7 +2555,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate45
+            get() = sharedCodeFormattingTemplate26
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2506,7 +2610,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate46
+            get() = sharedCodeFormattingTemplate47
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2561,7 +2665,7 @@ object Cpp {
         override val operatorDefinition: CppOperatorDefinition?
             get() = null
         override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate47
+            get() = sharedCodeFormattingTemplate48
         override val formatElementCount
             get() = 2
         override fun formatElement(
@@ -2604,51 +2708,6 @@ object Cpp {
             private val cmr = ChildMemberRelationships(
                 { n -> (n as MemberExpr).obj },
                 { n -> (n as MemberExpr).member },
-            )
-        }
-    }
-
-    class LiteralExpr(
-        pos: Position,
-        repr: Raw,
-    ) : BaseTree(pos), Expr {
-        override val operatorDefinition: CppOperatorDefinition?
-            get() = null
-        override val codeFormattingTemplate: CodeFormattingTemplate
-            get() = sharedCodeFormattingTemplate48
-        override val formatElementCount
-            get() = 1
-        override fun formatElement(
-            index: Int,
-        ): IndexableFormattableTreeElement {
-            return when (index) {
-                0 -> this.repr
-                else -> throw IndexOutOfBoundsException("$index")
-            }
-        }
-        private var _repr: Raw
-        var repr: Raw
-            get() = _repr
-            set(newValue) { _repr = updateTreeConnection(_repr, newValue) }
-        override fun deepCopy(): LiteralExpr {
-            return LiteralExpr(pos, repr = this.repr.deepCopy())
-        }
-        override val childMemberRelationships
-            get() = cmr
-        override fun equals(
-            other: Any?,
-        ): Boolean {
-            return other is LiteralExpr && this.repr == other.repr
-        }
-        override fun hashCode(): Int {
-            return repr.hashCode()
-        }
-        init {
-            this._repr = updateTreeConnection(null, repr)
-        }
-        companion object {
-            private val cmr = ChildMemberRelationships(
-                { n -> (n as LiteralExpr).repr },
             )
         }
     }
@@ -3487,8 +3546,23 @@ object Cpp {
             ),
         )
 
-    /** `/\* {{0}} *\/ {{1}}` */
+    /** `{{0}} [ {{1}} ]` */
     private val sharedCodeFormattingTemplate26 =
+        CodeFormattingTemplate.Concatenation(
+            listOf(
+                CodeFormattingTemplate.OneSubstitution(0),
+                CodeFormattingTemplate.LiteralToken("[", OutputTokenType.Punctuation, TokenAssociation.Bracket),
+                CodeFormattingTemplate.OneSubstitution(1),
+                CodeFormattingTemplate.LiteralToken("]", OutputTokenType.Punctuation, TokenAssociation.Bracket),
+            ),
+        )
+
+    /** `{{0}}` */
+    private val sharedCodeFormattingTemplate27 =
+        CodeFormattingTemplate.OneSubstitution(0)
+
+    /** `/\* {{0}} *\/ {{1}}` */
+    private val sharedCodeFormattingTemplate28 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("/*", OutputTokenType.Comment),
@@ -3499,7 +3573,7 @@ object Cpp {
         )
 
     /** `{{0}} /\* {{1}} *\/` */
-    private val sharedCodeFormattingTemplate27 =
+    private val sharedCodeFormattingTemplate29 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3510,7 +3584,7 @@ object Cpp {
         )
 
     /** `{{0}} const` */
-    private val sharedCodeFormattingTemplate28 =
+    private val sharedCodeFormattingTemplate30 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3519,7 +3593,7 @@ object Cpp {
         )
 
     /** `{{0}} *` */
-    private val sharedCodeFormattingTemplate29 =
+    private val sharedCodeFormattingTemplate31 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3528,7 +3602,7 @@ object Cpp {
         )
 
     /** `{{0}} < {{1*,}} >` */
-    private val sharedCodeFormattingTemplate30 =
+    private val sharedCodeFormattingTemplate32 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3542,7 +3616,7 @@ object Cpp {
         )
 
     /** `{{0}} ;` */
-    private val sharedCodeFormattingTemplate31 =
+    private val sharedCodeFormattingTemplate33 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3551,7 +3625,7 @@ object Cpp {
         )
 
     /** `{{0}} : {{1}}` */
-    private val sharedCodeFormattingTemplate32 =
+    private val sharedCodeFormattingTemplate34 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3561,7 +3635,7 @@ object Cpp {
         )
 
     /** `goto {{0}} ;` */
-    private val sharedCodeFormattingTemplate33 =
+    private val sharedCodeFormattingTemplate35 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("goto", OutputTokenType.Word),
@@ -3571,7 +3645,7 @@ object Cpp {
         )
 
     /** `return {{0}} ;` */
-    private val sharedCodeFormattingTemplate34 =
+    private val sharedCodeFormattingTemplate36 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("return", OutputTokenType.Word),
@@ -3581,7 +3655,7 @@ object Cpp {
         )
 
     /** `return ;` */
-    private val sharedCodeFormattingTemplate35 =
+    private val sharedCodeFormattingTemplate37 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("return", OutputTokenType.Word),
@@ -3590,7 +3664,7 @@ object Cpp {
         )
 
     /** `throw {{0}} ;` */
-    private val sharedCodeFormattingTemplate36 =
+    private val sharedCodeFormattingTemplate38 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("throw", OutputTokenType.Word),
@@ -3600,7 +3674,7 @@ object Cpp {
         )
 
     /** `try {{0}} catch ( const temper :: core :: TemperBubble & ) {{1}}` */
-    private val sharedCodeFormattingTemplate37 =
+    private val sharedCodeFormattingTemplate39 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("try", OutputTokenType.Word),
@@ -3620,7 +3694,7 @@ object Cpp {
         )
 
     /** `break ;` */
-    private val sharedCodeFormattingTemplate38 =
+    private val sharedCodeFormattingTemplate40 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("break", OutputTokenType.Word),
@@ -3629,7 +3703,7 @@ object Cpp {
         )
 
     /** `switch ( {{0}} ) \{ {{1*}} default : {{2}} \}` */
-    private val sharedCodeFormattingTemplate39 =
+    private val sharedCodeFormattingTemplate41 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("switch", OutputTokenType.Word),
@@ -3649,7 +3723,7 @@ object Cpp {
         )
 
     /** `if ( {{0}} ) {{1}} else {{2}}` */
-    private val sharedCodeFormattingTemplate40 =
+    private val sharedCodeFormattingTemplate42 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("if", OutputTokenType.Word),
@@ -3663,7 +3737,7 @@ object Cpp {
         )
 
     /** `if ( {{0}} ) {{1}}` */
-    private val sharedCodeFormattingTemplate41 =
+    private val sharedCodeFormattingTemplate43 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("if", OutputTokenType.Word),
@@ -3675,7 +3749,7 @@ object Cpp {
         )
 
     /** `while ( {{0}} ) {{1}}` */
-    private val sharedCodeFormattingTemplate42 =
+    private val sharedCodeFormattingTemplate44 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("while", OutputTokenType.Word),
@@ -3687,7 +3761,7 @@ object Cpp {
         )
 
     /** `{{0*}} {{1}}` */
-    private val sharedCodeFormattingTemplate43 =
+    private val sharedCodeFormattingTemplate45 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.GroupSubstitution(
@@ -3699,7 +3773,7 @@ object Cpp {
         )
 
     /** `case {{0}} :` */
-    private val sharedCodeFormattingTemplate44 =
+    private val sharedCodeFormattingTemplate46 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.LiteralToken("case", OutputTokenType.Word),
@@ -3708,19 +3782,8 @@ object Cpp {
             ),
         )
 
-    /** `{{0}} [ {{1}} ]` */
-    private val sharedCodeFormattingTemplate45 =
-        CodeFormattingTemplate.Concatenation(
-            listOf(
-                CodeFormattingTemplate.OneSubstitution(0),
-                CodeFormattingTemplate.LiteralToken("[", OutputTokenType.Punctuation, TokenAssociation.Bracket),
-                CodeFormattingTemplate.OneSubstitution(1),
-                CodeFormattingTemplate.LiteralToken("]", OutputTokenType.Punctuation, TokenAssociation.Bracket),
-            ),
-        )
-
     /** `{{0}} ( {{1*,}} )` */
-    private val sharedCodeFormattingTemplate46 =
+    private val sharedCodeFormattingTemplate47 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3734,7 +3797,7 @@ object Cpp {
         )
 
     /** `{{0}} . {{1}}` */
-    private val sharedCodeFormattingTemplate47 =
+    private val sharedCodeFormattingTemplate48 =
         CodeFormattingTemplate.Concatenation(
             listOf(
                 CodeFormattingTemplate.OneSubstitution(0),
@@ -3742,10 +3805,6 @@ object Cpp {
                 CodeFormattingTemplate.OneSubstitution(1),
             ),
         )
-
-    /** `{{0}}` */
-    private val sharedCodeFormattingTemplate48 =
-        CodeFormattingTemplate.OneSubstitution(0)
 
     /** `{{0}} {{1}} {{2}}` */
     private val sharedCodeFormattingTemplate49 =

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.kt
@@ -151,6 +151,7 @@ object Cpp {
 
     class FuncDecl(
         pos: Position,
+        attr: SingleName? = null,
         var mod: DefMod? = null,
         ret: Type?,
         convention: SingleName? = null,
@@ -163,20 +164,25 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() = sharedCodeFormattingTemplate2
         override val formatElementCount
-            get() = 6
+            get() = 7
         override fun formatElement(
             index: Int,
         ): IndexableFormattableTreeElement {
             return when (index) {
-                0 -> this.mod ?: FormattableTreeGroup.empty
-                1 -> this.ret ?: FormattableTreeGroup.empty
-                2 -> this.convention ?: FormattableTreeGroup.empty
-                3 -> this.name
-                4 -> FormattableTreeGroup(this.args)
-                5 -> this.qual ?: FormattableTreeGroup.empty
+                0 -> this.attr ?: FormattableTreeGroup.empty
+                1 -> this.mod ?: FormattableTreeGroup.empty
+                2 -> this.ret ?: FormattableTreeGroup.empty
+                3 -> this.convention ?: FormattableTreeGroup.empty
+                4 -> this.name
+                5 -> FormattableTreeGroup(this.args)
+                6 -> this.qual ?: FormattableTreeGroup.empty
                 else -> throw IndexOutOfBoundsException("$index")
             }
         }
+        private var _attr: SingleName?
+        var attr: SingleName?
+            get() = _attr
+            set(newValue) { _attr = updateTreeConnection(_attr, newValue) }
         private var _ret: Type?
         var ret: Type?
             get() = _ret
@@ -194,17 +200,18 @@ object Cpp {
             get() = _args
             set(newValue) { updateTreeConnections(_args, newValue) }
         override fun deepCopy(): FuncDecl {
-            return FuncDecl(pos, mod = this.mod, ret = this.ret?.deepCopy(), convention = this.convention?.deepCopy(), name = this.name.deepCopy(), args = this.args.deepCopy(), qual = this.qual)
+            return FuncDecl(pos, attr = this.attr?.deepCopy(), mod = this.mod, ret = this.ret?.deepCopy(), convention = this.convention?.deepCopy(), name = this.name.deepCopy(), args = this.args.deepCopy(), qual = this.qual)
         }
         override val childMemberRelationships
             get() = cmr
         override fun equals(
             other: Any?,
         ): Boolean {
-            return other is FuncDecl && this.mod == other.mod && this.ret == other.ret && this.convention == other.convention && this.name == other.name && this.args == other.args && this.qual == other.qual
+            return other is FuncDecl && this.attr == other.attr && this.mod == other.mod && this.ret == other.ret && this.convention == other.convention && this.name == other.name && this.args == other.args && this.qual == other.qual
         }
         override fun hashCode(): Int {
-            var hc = (mod?.hashCode() ?: 0)
+            var hc = (attr?.hashCode() ?: 0)
+            hc = 31 * hc + (mod?.hashCode() ?: 0)
             hc = 31 * hc + (ret?.hashCode() ?: 0)
             hc = 31 * hc + (convention?.hashCode() ?: 0)
             hc = 31 * hc + name.hashCode()
@@ -213,6 +220,7 @@ object Cpp {
             return hc
         }
         init {
+            this._attr = updateTreeConnection(null, attr)
             this._ret = updateTreeConnection(null, ret)
             this._convention = updateTreeConnection(null, convention)
             this._name = updateTreeConnection(null, name)
@@ -220,6 +228,7 @@ object Cpp {
         }
         companion object {
             private val cmr = ChildMemberRelationships(
+                { n -> (n as FuncDecl).attr },
                 { n -> (n as FuncDecl).ret },
                 { n -> (n as FuncDecl).convention },
                 { n -> (n as FuncDecl).name },
@@ -628,6 +637,7 @@ object Cpp {
 
     class FuncDef(
         pos: Position,
+        attr: SingleName? = null,
         var mod: DefMod? = null,
         ret: Type?,
         convention: SingleName? = null,
@@ -641,21 +651,26 @@ object Cpp {
         override val codeFormattingTemplate: CodeFormattingTemplate
             get() = sharedCodeFormattingTemplate8
         override val formatElementCount
-            get() = 7
+            get() = 8
         override fun formatElement(
             index: Int,
         ): IndexableFormattableTreeElement {
             return when (index) {
-                0 -> this.mod ?: FormattableTreeGroup.empty
-                1 -> this.ret ?: FormattableTreeGroup.empty
-                2 -> this.convention ?: FormattableTreeGroup.empty
-                3 -> this.name
-                4 -> FormattableTreeGroup(this.args)
-                5 -> this.qual ?: FormattableTreeGroup.empty
-                6 -> this.body
+                0 -> this.attr ?: FormattableTreeGroup.empty
+                1 -> this.mod ?: FormattableTreeGroup.empty
+                2 -> this.ret ?: FormattableTreeGroup.empty
+                3 -> this.convention ?: FormattableTreeGroup.empty
+                4 -> this.name
+                5 -> FormattableTreeGroup(this.args)
+                6 -> this.qual ?: FormattableTreeGroup.empty
+                7 -> this.body
                 else -> throw IndexOutOfBoundsException("$index")
             }
         }
+        private var _attr: SingleName?
+        var attr: SingleName?
+            get() = _attr
+            set(newValue) { _attr = updateTreeConnection(_attr, newValue) }
         private var _ret: Type?
         var ret: Type?
             get() = _ret
@@ -677,17 +692,18 @@ object Cpp {
             get() = _body
             set(newValue) { _body = updateTreeConnection(_body, newValue) }
         override fun deepCopy(): FuncDef {
-            return FuncDef(pos, mod = this.mod, ret = this.ret?.deepCopy(), convention = this.convention?.deepCopy(), name = this.name.deepCopy(), args = this.args.deepCopy(), qual = this.qual, body = this.body.deepCopy())
+            return FuncDef(pos, attr = this.attr?.deepCopy(), mod = this.mod, ret = this.ret?.deepCopy(), convention = this.convention?.deepCopy(), name = this.name.deepCopy(), args = this.args.deepCopy(), qual = this.qual, body = this.body.deepCopy())
         }
         override val childMemberRelationships
             get() = cmr
         override fun equals(
             other: Any?,
         ): Boolean {
-            return other is FuncDef && this.mod == other.mod && this.ret == other.ret && this.convention == other.convention && this.name == other.name && this.args == other.args && this.qual == other.qual && this.body == other.body
+            return other is FuncDef && this.attr == other.attr && this.mod == other.mod && this.ret == other.ret && this.convention == other.convention && this.name == other.name && this.args == other.args && this.qual == other.qual && this.body == other.body
         }
         override fun hashCode(): Int {
-            var hc = (mod?.hashCode() ?: 0)
+            var hc = (attr?.hashCode() ?: 0)
+            hc = 31 * hc + (mod?.hashCode() ?: 0)
             hc = 31 * hc + (ret?.hashCode() ?: 0)
             hc = 31 * hc + (convention?.hashCode() ?: 0)
             hc = 31 * hc + name.hashCode()
@@ -697,6 +713,7 @@ object Cpp {
             return hc
         }
         init {
+            this._attr = updateTreeConnection(null, attr)
             this._ret = updateTreeConnection(null, ret)
             this._convention = updateTreeConnection(null, convention)
             this._name = updateTreeConnection(null, name)
@@ -705,6 +722,7 @@ object Cpp {
         }
         companion object {
             private val cmr = ChildMemberRelationships(
+                { n -> (n as FuncDef).attr },
                 { n -> (n as FuncDef).ret },
                 { n -> (n as FuncDef).convention },
                 { n -> (n as FuncDef).name },
@@ -3127,7 +3145,7 @@ object Cpp {
             ),
         )
 
-    /** `{{0}} {{1}} {{2}} {{3}} ( {{4*,}} ) {{5}} ;` */
+    /** `{{0}} {{1}} {{2}} {{3}} {{4}} ( {{5*,}} ) {{6}} ;` */
     private val sharedCodeFormattingTemplate2 =
         CodeFormattingTemplate.Concatenation(
             listOf(
@@ -3135,13 +3153,14 @@ object Cpp {
                 CodeFormattingTemplate.OneSubstitution(1),
                 CodeFormattingTemplate.OneSubstitution(2),
                 CodeFormattingTemplate.OneSubstitution(3),
+                CodeFormattingTemplate.OneSubstitution(4),
                 CodeFormattingTemplate.LiteralToken("(", OutputTokenType.Punctuation, TokenAssociation.Bracket),
                 CodeFormattingTemplate.GroupSubstitution(
-                    4,
+                    5,
                     CodeFormattingTemplate.LiteralToken(",", OutputTokenType.Punctuation),
                 ),
                 CodeFormattingTemplate.LiteralToken(")", OutputTokenType.Punctuation, TokenAssociation.Bracket),
-                CodeFormattingTemplate.OneSubstitution(5),
+                CodeFormattingTemplate.OneSubstitution(6),
                 CodeFormattingTemplate.LiteralToken(";", OutputTokenType.Punctuation),
             ),
         )
@@ -3220,7 +3239,7 @@ object Cpp {
             ),
         )
 
-    /** `{{0}} {{1}} {{2}} {{3}} ( {{4*,}} ) {{5}} {{6}}` */
+    /** `{{0}} {{1}} {{2}} {{3}} {{4}} ( {{5*,}} ) {{6}} {{7}}` */
     private val sharedCodeFormattingTemplate8 =
         CodeFormattingTemplate.Concatenation(
             listOf(
@@ -3228,14 +3247,15 @@ object Cpp {
                 CodeFormattingTemplate.OneSubstitution(1),
                 CodeFormattingTemplate.OneSubstitution(2),
                 CodeFormattingTemplate.OneSubstitution(3),
+                CodeFormattingTemplate.OneSubstitution(4),
                 CodeFormattingTemplate.LiteralToken("(", OutputTokenType.Punctuation, TokenAssociation.Bracket),
                 CodeFormattingTemplate.GroupSubstitution(
-                    4,
+                    5,
                     CodeFormattingTemplate.LiteralToken(",", OutputTokenType.Punctuation),
                 ),
                 CodeFormattingTemplate.LiteralToken(")", OutputTokenType.Punctuation, TokenAssociation.Bracket),
-                CodeFormattingTemplate.OneSubstitution(5),
                 CodeFormattingTemplate.OneSubstitution(6),
+                CodeFormattingTemplate.OneSubstitution(7),
             ),
         )
 

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
@@ -61,8 +61,12 @@ FuncDef.qual.default = `null`;
 FuncParam ::= type%Type & name%SingleName;
 
 VarDecl ::= "extern" & type%Type & name%SingleName & ";";
-VarDef ::= mod%DefMod? & type%Type & name%Name & ("=" & init%Expr || ()) & ";";
+VarDef ::= mod%DefMod? & type%Type & name%VarDefNamePart & ("=" & init%Expr || ()) & ";";
 VarDef.mod.default = `null`;
+
+// TODO Some equivalent for VarDecl when need that.
+VarDefNamePart = Name | ArrayVarDefDim;
+ArrayVarDefDim ::= name%VarDefNamePart & "[" & dim%LiteralExpr? & "]";
 
 TypeDef ::= "typedef" & type%Type & name%SingleName & ";";
 

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/Cpp.out-grammar
@@ -47,11 +47,14 @@ enum DefMod = Static;
 enum MethodQualifier = Const;
 
 // Optional return type allows for constructors.
-FuncDecl ::= mod%DefMod? & ret%Type? & convention%SingleName? & name%SingleName & "(" & args%Type*"," & ")" & qual%MethodQualifier? & ";";
+// Attribute should be richer, but SingleName allows using some `#define`.
+FuncDecl ::= attr%SingleName? & mod%DefMod? & ret%Type? & convention%SingleName? & name%SingleName & "(" & args%Type*"," & ")" & qual%MethodQualifier? & ";";
+FuncDecl.attr.default = `null`;
 FuncDecl.mod.default = `null`;
 FuncDecl.convention.default = `null`;
 FuncDecl.qual.default = `null`;
-FuncDef ::= mod%DefMod? & ret%Type? & convention%SingleName? & name%Name & "(" & args%FuncParam*"," & ")" & qual%MethodQualifier? & body%BlockStmt;
+FuncDef ::= attr%SingleName? & mod%DefMod? & ret%Type? & convention%SingleName? & name%Name & "(" & args%FuncParam*"," & ")" & qual%MethodQualifier? & body%BlockStmt;
+FuncDef.attr.default = `null`;
 FuncDef.mod.default = `null`;
 FuncDef.convention.default = `null`;
 FuncDef.qual.default = `null`;

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
@@ -177,8 +177,8 @@ class CppBuilder(
         Cpp.VarDef(pos, mod, type.deepCopy(), name.deepCopy(), init?.deepCopy())
     fun varDef(type: Cpp.Type, name: Cpp.VarDefNamePart, init: Cpp.Expr? = null): Cpp.VarDef =
         varDef(mod = null, type, name, init = init)
-    fun varDefArray(name: Cpp.VarDefNamePart, dim: Int): Cpp.ArrayVarDefDim =
-        Cpp.ArrayVarDefDim(pos, name.deepCopy(), literal(dim))
+    fun varDefArray(name: Cpp.VarDefNamePart, dim: Cpp.LiteralExpr): Cpp.ArrayVarDefDim =
+        Cpp.ArrayVarDefDim(pos, name.deepCopy(), dim.deepCopy())
 
     fun const(type: Cpp.Type): Cpp.ConstType =
         Cpp.ConstType(pos, type.deepCopy())

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
@@ -141,7 +141,7 @@ class CppBuilder(
     ): Cpp.FuncDef =
         Cpp.FuncDef(
             pos,
-            attr = attr,
+            attr = attr?.deepCopy(),
             mod = mod,
             ret = ret?.deepCopy(),
             convention = convention?.deepCopy(),
@@ -178,7 +178,7 @@ class CppBuilder(
     fun varDef(type: Cpp.Type, name: Cpp.VarDefNamePart, init: Cpp.Expr? = null): Cpp.VarDef =
         varDef(mod = null, type, name, init = init)
     fun varDefArray(name: Cpp.VarDefNamePart, dim: Int): Cpp.ArrayVarDefDim =
-        Cpp.ArrayVarDefDim(pos, name, literal(dim))
+        Cpp.ArrayVarDefDim(pos, name.deepCopy(), literal(dim))
 
     fun const(type: Cpp.Type): Cpp.ConstType =
         Cpp.ConstType(pos, type.deepCopy())

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
@@ -173,10 +173,12 @@ class CppBuilder(
 
     fun varDecl(type: Cpp.Type, name: Cpp.SingleName): Cpp.VarDecl =
         Cpp.VarDecl(pos, type = type.deepCopy(), name = name.deepCopy())
-    fun varDef(mod: Cpp.DefMod?, type: Cpp.Type, name: Cpp.SingleName, init: Cpp.Expr? = null): Cpp.VarDef =
+    fun varDef(mod: Cpp.DefMod?, type: Cpp.Type, name: Cpp.VarDefNamePart, init: Cpp.Expr? = null): Cpp.VarDef =
         Cpp.VarDef(pos, mod, type.deepCopy(), name.deepCopy(), init?.deepCopy())
-    fun varDef(type: Cpp.Type, name: Cpp.SingleName, init: Cpp.Expr? = null): Cpp.VarDef =
+    fun varDef(type: Cpp.Type, name: Cpp.VarDefNamePart, init: Cpp.Expr? = null): Cpp.VarDef =
         varDef(mod = null, type, name, init = init)
+    fun varDefArray(name: Cpp.VarDefNamePart, dim: Int): Cpp.ArrayVarDefDim =
+        Cpp.ArrayVarDefDim(pos, name, literal(dim))
 
     fun const(type: Cpp.Type): Cpp.ConstType =
         Cpp.ConstType(pos, type.deepCopy())

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBuilder.kt
@@ -130,6 +130,7 @@ class CppBuilder(
             args = args.deepCopy(),
         )
     fun funcDef(
+        attr: Cpp.SingleName?,
         mod: Cpp.DefMod?,
         ret: Cpp.Type?,
         convention: Cpp.SingleName?,
@@ -140,6 +141,7 @@ class CppBuilder(
     ): Cpp.FuncDef =
         Cpp.FuncDef(
             pos,
+            attr = attr,
             mod = mod,
             ret = ret?.deepCopy(),
             convention = convention?.deepCopy(),
@@ -165,7 +167,7 @@ class CppBuilder(
             body = body.deepCopy(),
         )
     fun funcDef(ret: Cpp.Type?, name: Cpp.Name, args: Iterable<Cpp.FuncParam>, body: Cpp.BlockStmt): Cpp.FuncDef =
-        funcDef(mod = null, ret, convention = null, name, args, body)
+        funcDef(attr = null, mod = null, ret, convention = null, name, args, body)
     fun funcParam(type: Cpp.Type, name: Cpp.SingleName): Cpp.FuncParam =
         Cpp.FuncParam(pos, type.deepCopy(), name.deepCopy())
 
@@ -310,6 +312,7 @@ class CppBuilder(
                 qual = qual,
             ),
             def = funcDef(
+                attr = null,
                 mod = null,
                 retType,
                 convention = convention,

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -562,7 +562,7 @@ class CppTranslator(
         name: Cpp.SingleName,
         params: List<Cpp.FuncParam> = emptyList(),
         qual: Cpp.MethodQualifier? = null,
-    ): Cpp.FuncDef = cpp.funcDef(null, retType, virtualConvention, name, params, pureVirtualBody(), qual = qual)
+    ): Cpp.FuncDef = cpp.funcDef(null, null, retType, virtualConvention, name, params, pureVirtualBody(), qual = qual)
 
     /**
      * The `const` qualifier for a member (method or getter) that does not mutate its
@@ -2726,6 +2726,7 @@ class CppTranslator(
                                 }
                                 val rawParent = "$parentText<$typeParamStr>"
                                 cpp.funcDef(
+                                    methodDef.attr,
                                     methodDef.mod,
                                     methodDef.ret,
                                     methodDef.convention,
@@ -2803,6 +2804,7 @@ class CppTranslator(
                 val dtorName = "~${cpp.name(topLevel.name).id.text}"
                 add(
                     cpp.funcDef(
+                        null,
                         null,
                         null,
                         cpp.singleName(CppName("virtual", allowKey = true)),

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/Java.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/Java.kt
@@ -5509,7 +5509,7 @@ object Java {
         pos: Position,
         type: QualIdentifier,
         field: Identifier,
-    ) : BaseTree(pos), Expression {
+    ) : BaseTree(pos), Expression, LeftHandSide {
         override val operatorDefinition
             get() = JavaOperatorDefinition.Atom
         override val codeFormattingTemplate: CodeFormattingTemplate

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
@@ -136,7 +136,7 @@ class JavaBackend private constructor(
     private var rootMainClass: QualifiedName? = null
 
     override fun translate(finished: TmpL.ModuleSet) = buildList {
-        JavaTranslator(names, dependenciesBuilder).let { trans ->
+        JavaTranslator(names, dependenciesBuilder, adjuster).let { trans ->
             names.scanNames(finished)
             finished.modules.flatMap { tmpLModule ->
                 trans.translate(tmpLModule)

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
@@ -136,7 +136,7 @@ class JavaBackend private constructor(
     private var rootMainClass: QualifiedName? = null
 
     override fun translate(finished: TmpL.ModuleSet) = buildList {
-        JavaTranslator(names, dependenciesBuilder, adjuster).let { trans ->
+        JavaTranslator(names, dependenciesBuilder, adjusterFactory).let { trans ->
             names.scanNames(finished)
             finished.modules.flatMap { tmpLModule ->
                 trans.translate(tmpLModule)

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
@@ -2,6 +2,7 @@ package lang.temper.be.java
 
 import lang.temper.ast.deepSlice
 import lang.temper.ast.toLispy
+import lang.temper.be.BackendAdjuster
 import lang.temper.be.Dependencies
 import lang.temper.be.java.JavaOperator.Assign
 import lang.temper.be.tmpl.FnAutodoc
@@ -66,6 +67,7 @@ class JavaTranslator(
     /** a shared instance for consistent name mapping */
     private val topNames: JavaNames,
     private val dependenciesBuilder: Dependencies.Builder<JavaBackend>? = null,
+    private val adjuster: BackendAdjuster? = null,
 ) {
     /** Spin off an instance for a given module */
     private fun forModule(module: ModuleName, programMeta: J.ProgramMeta = J.ProgramMeta(unknownPos)): ModuleScope =
@@ -481,7 +483,9 @@ class JavaTranslator(
                             }.also { add(it.asNameExpr().asArgument()) }
                         }
                     },
-                ).exprOrReturnStatement(shouldReturn = result !is J.VoidType).also { add(it) }
+                ).let { call ->
+                    adjuster?.adjustConnectedCall(fn, call as J.ExpressionStatementExpr) ?: call
+                }.exprOrReturnStatement(shouldReturn = result !is J.VoidType).also { add(it) }
             }.let { J.BlockStatement(pos, it) }
         }
 

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
@@ -161,7 +161,7 @@ class JavaTranslator(
 
         fun module(module: TmpL.Module): List<J.Program> {
             this.module = module
-            adjuster = adjusterFactory?.makeAdjuster(module)
+            adjuster = adjusterFactory?.makeAdjuster(module, this)
             val result = module.result
             topLevels@ for (tl in module.topLevels) {
                 try {
@@ -525,7 +525,7 @@ class JavaTranslator(
         private fun moduleFunction(t: TmpL.FunctionDeclaration) {
             val autodoc = autodocFor(t)
             val name = names.moduleFunction(t.name).second.toIdentifier(t.name.pos)
-            val result = resultType(names, t.returnType, pos = t.returnType.pos)
+            val result = resultType(t)
             val body = when {
                 t.metadata.any { it.key.symbol == connectedSymbol } && module?.isStdLib != true ->
                     connectedBody(t, result)
@@ -906,7 +906,7 @@ class JavaTranslator(
                             }
                         }
                         is TmpL.Getter -> {
-                            val result = resultType(names, m.returnType, m.pos)
+                            val result = resultType(m)
                             val name = names.getterName(m.dotName, JavaType.toFrontend(m.returnType.ot))
                             val parameters = parameters(m.parameters)
                             val prop = t.members.firstNotNullOfOrNull {
@@ -932,7 +932,7 @@ class JavaTranslator(
                             )
                         }
                         is TmpL.Setter -> {
-                            val result = resultType(names, m.returnType, m.pos)
+                            val result = resultType(m)
                             val name = names.setterName(m.dotName)
                             val parameters = parameters(m.parameters)
                             add(
@@ -966,7 +966,7 @@ class JavaTranslator(
                                     J.ModStatic.Dynamic
                                 },
                             )
-                            val tentativeResult = resultType(names, m.returnType, m.pos)
+                            val tentativeResult = resultType(m)
 
                             val boxedTypeAdjustments = (m as? TmpL.NormalMethod)?.let {
                                 findJavaParametersThatNeedAdjustmentToBoxedType(
@@ -1074,7 +1074,7 @@ class JavaTranslator(
                                         modAccess = access(m),
                                         modFinal = final(m.assignOnce),
                                     ),
-                                    type = JavaType.fromTmpL(m.type, names).toTypeAst(m.pos),
+                                    type = varType(m),
                                     variable = names.field(m.name),
                                     initializer = null,
                                 ),
@@ -1090,7 +1090,7 @@ class JavaTranslator(
                                     modFinal = final(m.assignOnce),
                                     modStatic = J.ModStatic.Static,
                                 ),
-                                type = JavaType.fromTmpL(m.type, names).toTypeAst(m.pos),
+                                type = varType(m),
                                 variable = names.staticField(m.dotName),
                                 initializer = expr(m.expression),
                             ),
@@ -1172,7 +1172,7 @@ class JavaTranslator(
                                 pos = m.pos,
                                 autodoc = autodocFor(m),
                                 body = m.body,
-                                result = resultType(names, m.returnType, m.pos),
+                                result = resultType(m),
                                 name = names.getterName(m.dotName, JavaType.toFrontend(m.returnType.ot)),
                                 params = parameters(m.parameters),
                             ),
@@ -1182,7 +1182,7 @@ class JavaTranslator(
                                 pos = m.pos,
                                 autodoc = autodocFor(m),
                                 body = m.body,
-                                result = resultType(names, m.returnType, m.pos),
+                                result = resultType(m),
                                 name = names.setterName(m.dotName),
                                 params = parameters(m.parameters),
                             ),
@@ -1192,7 +1192,7 @@ class JavaTranslator(
                                 pos = m.pos,
                                 autodoc = autodocFor(m),
                                 body = m.body,
-                                result = resultType(names, m.returnType, m.pos),
+                                result = resultType(m),
                                 name = names.method(m.dotName).toIdentifier(m.dotName.pos),
                                 params = parameters(m.parameters),
                                 typeParams = typeFormals(m.typeParameters),
@@ -1204,7 +1204,7 @@ class JavaTranslator(
                                 autodoc = autodocFor(m),
                                 body = m.body,
                                 name = names.method(m.dotName).toIdentifier(m.dotName.pos),
-                                result = resultType(names, m.returnType, m.pos),
+                                result = resultType(m),
                                 params = parameters(m.parameters),
                                 typeParams = typeFormals(m.typeParameters),
                                 isStatic = true,
@@ -1219,7 +1219,7 @@ class JavaTranslator(
                             J.InterfaceFieldDeclaration(
                                 pos = m.pos,
                                 javadoc = javadoc(autodocFor(m.pos, m.metadata)),
-                                type = JavaType.fromTmpL(m.type, names).toTypeAst(m.type.pos),
+                                type = varType(m),
                                 variables = listOf(
                                     J.VariableDeclarator(
                                         m.pos,
@@ -1249,6 +1249,28 @@ class JavaTranslator(
                     ),
                 ),
             )
+        }
+
+        fun resultType(fn: TmpL.FunctionDeclarationOrMethod): J.ResultType {
+            // TODO Some manual calls chose the return type pos but most chose the function pos.
+            // TODO Maybe makes sense to standardize here, but which is best?
+            return resultType(names, fn.returnType, fn.pos)
+        }
+
+        fun resultType(type: TmpL.AType, pos: Position? = null): J.ResultType {
+            return resultType(names, type, pos ?: type.pos)
+        }
+
+        fun varType(property: TmpL.Property): J.Type {
+            return varType(property.type, property.pos)
+        }
+
+        fun varType(v: TmpL.VarLike): J.Type {
+            return JavaType.fromFrontend(v.descriptor, names).toTypeAst(v.pos)
+        }
+
+        fun varType(type: TmpL.AType, pos: Position? = null): J.Type {
+            return JavaType.fromTmpL(type, names).toTypeAst(pos ?: type.pos)
         }
 
         /** Create an object containing the method parameters and necessary preamble statements. */
@@ -1413,8 +1435,7 @@ class JavaTranslator(
                         scope.addDecl(
                             J.FieldDeclaration(
                                 pos,
-                                type = JavaType.fromTmpL(param.type, names)
-                                    .toTypeAst(pos),
+                                type = varType(param),
                                 variable = localName.outName.toIdentifier(varId.pos),
                                 initializer = newNames[oldName.outName]!!.toNameExpr(varId.pos),
                             ),
@@ -1460,7 +1481,7 @@ class JavaTranslator(
                             scope.addDecl(
                                 J.FieldDeclaration(
                                     stmt.pos,
-                                    type = JavaType.fromTmpL(stmt.type, names).toTypeAst(stmt.pos),
+                                    type = varType(stmt),
                                     variable = localName.outName.toIdentifier(varId.pos),
                                     initializer = stmt.init?.let(::expr),
                                 ),
@@ -1501,7 +1522,7 @@ class JavaTranslator(
                 stmts.add(
                     J.LocalVariableDeclaration(
                         pos,
-                        type = JavaType.fromTmpL(param.type, names).toTypeAst(pos),
+                        type = varType(param),
                         name = newName.toIdentifier(varId.pos),
                         expr = oldName.toIdentifier(varId.pos).asNameExpr(),
                     ),
@@ -1577,7 +1598,7 @@ class JavaTranslator(
             val javaType: J.Type get() = JavaType.fromSig(funcType, names).toTypeAst(pos)
 
             /** the result type of the function */
-            val javaResultType: J.ResultType get() = resultType(names, tmplFunc.returnType, tmplFunc.returnType.pos)
+            val javaResultType: J.ResultType get() = resultType(tmplFunc)
 
             /** a lambda expression can be used in a local variable declaration, or also in a forward declared form. */
             fun toLambdaExpr() =
@@ -1667,7 +1688,7 @@ class JavaTranslator(
         private fun localVar(t: TmpL.LocalDeclaration) =
             J.LocalVariableDeclaration(
                 t.pos,
-                type = JavaType.fromTmpL(t.type, names).toTypeAst(t.pos),
+                type = varType(t),
                 name = names.lookupRegularLocalNameObj(t.name).outName.toIdentifier(t.name.pos),
                 expr = t.init?.let(::expr),
             )

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
@@ -3,6 +3,7 @@ package lang.temper.be.java
 import lang.temper.ast.deepSlice
 import lang.temper.ast.toLispy
 import lang.temper.be.BackendAdjuster
+import lang.temper.be.BackendAdjusterFactory
 import lang.temper.be.Dependencies
 import lang.temper.be.java.JavaOperator.Assign
 import lang.temper.be.tmpl.FnAutodoc
@@ -67,7 +68,7 @@ class JavaTranslator(
     /** a shared instance for consistent name mapping */
     private val topNames: JavaNames,
     private val dependenciesBuilder: Dependencies.Builder<JavaBackend>? = null,
-    private val adjuster: BackendAdjuster? = null,
+    private val adjusterFactory: BackendAdjusterFactory? = null,
 ) {
     /** Spin off an instance for a given module */
     private fun forModule(module: ModuleName, programMeta: J.ProgramMeta = J.ProgramMeta(unknownPos)): ModuleScope =
@@ -134,6 +135,7 @@ class JavaTranslator(
 
         /** Might even stay null for snippets. */
         private var module: TmpL.Module? = null
+        private var adjuster: BackendAdjuster? = null
 
         private fun activeDecls(decls: MutableList<J.ClassBodyDeclaration>) = when {
             processingTestCode -> moduleTestDecls
@@ -159,6 +161,7 @@ class JavaTranslator(
 
         fun module(module: TmpL.Module): List<J.Program> {
             this.module = module
+            adjuster = adjusterFactory?.makeAdjuster(module)
             val result = module.result
             topLevels@ for (tl in module.topLevels) {
                 try {
@@ -238,6 +241,7 @@ class JavaTranslator(
                     addAll(moduleTestDecls)
                 }
             }
+            adjuster?.also { programs.addAll(it.additionalFilesAfterTranslation()) }
             return programs
         }
 

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaTranslator.kt
@@ -241,7 +241,7 @@ class JavaTranslator(
                     addAll(moduleTestDecls)
                 }
             }
-            adjuster?.also { programs.addAll(it.additionalFilesAfterTranslation()) }
+            adjuster?.adjustFilesAfterTranslation(programs)
             return programs
         }
 

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/NameHelpers.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/NameHelpers.kt
@@ -46,4 +46,4 @@ internal fun ResolvedName.simpleText(): String = when (this) {
 internal fun ResolvedName.distinctSafeText() = distinctText().safeIdentifier()
 
 /** Apply a simple set of rules to extract a name's text and ensure the identifier is safe for Java. */
-internal fun ResolvedName.simpleSafeText() = simpleText().safeIdentifier()
+fun ResolvedName.simpleSafeText() = simpleText().safeIdentifier()

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/SimplifyNames.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/SimplifyNames.kt
@@ -446,6 +446,7 @@ class SimplifyNames(private val top: J.TopLevelClassDeclaration) {
     private fun Scope.scanLhs(e: J.LeftHandSide) = when (e) {
         is J.FieldAccessExpr -> scanExpr(e.expr)
         is J.NameExpr -> scanName(e)
+        is J.StaticFieldAccessExpr -> importType(e.type)
     }
 
     private fun Scope.scanArgs(ax: Iterable<J.Argument>) = ax.forEach { scanExpr(it.expr) }

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/java.out-grammar
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/java.out-grammar
@@ -518,10 +518,10 @@ ConstructorDeclaration requires `parameters.validArity()`;
 ConstructorDeclaration requires `body.constructorBlock()`;
 
 /*
- * Consolidates reciever parameters, formals, and variable arity parameters into MethodParameter.
+ * Consolidates receiver parameters, formals, and variable arity parameters into MethodParameter.
  * Variable arity parameters are required for 'rest' spread and other conveniences.
  *
- * We won't implement reciever parameters unless we need to either:
+ * We won't implement receiver parameters unless we need to either:
  * - annotate `this`
  * - for a nested class to specifically get a reference to its outer class
  */

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/java.out-grammar
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/java.out-grammar
@@ -1266,7 +1266,7 @@ AssignmentExpr requires `operator.operator.isAssignment()` ;
  * The target of an assignment may be a name, or an accessor.
  * JLS 15.26 TODO add array access
  */
-LeftHandSide = NameExpr | FieldAccessExpr ;
+LeftHandSide = NameExpr | FieldAccessExpr | StaticFieldAccessExpr ;
 
 /**
  * A lambda expression. JLS 15.27

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
@@ -160,6 +160,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
                 outputRoot = outputRoot,
                 preparedModules = preparedModules,
                 test = test,
+                adjuster = backendOrganization.adjusters[neededBackendId],
             )
         }
 
@@ -204,6 +205,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
         outputRoot: OutputRoot,
         preparedModules: PreparedFunctionalTest,
         test: FunctionalTestBase,
+        adjuster: BackendAdjuster?,
     ) = run {
         val supportedBackendList = listOf(backendId)
         val functionalTestLibraryConfiguration = LibraryConfiguration(
@@ -313,6 +315,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
                     config = config,
                     dependenciesBuilder = dependenciesBuilder,
                     rawBackendFiles = rawBackendFiles,
+                    adjuster = adjuster,
                 ),
             )
         }

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
@@ -160,7 +160,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
                 outputRoot = outputRoot,
                 preparedModules = preparedModules,
                 test = test,
-                adjuster = backendOrganization.adjusters[neededBackendId],
+                adjusterFactory = backendOrganization.adjusterFactories[neededBackendId],
             )
         }
 
@@ -205,7 +205,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
         outputRoot: OutputRoot,
         preparedModules: PreparedFunctionalTest,
         test: FunctionalTestBase,
-        adjuster: BackendAdjuster?,
+        adjusterFactory: BackendAdjusterFactory?,
     ) = run {
         val supportedBackendList = listOf(backendId)
         val functionalTestLibraryConfiguration = LibraryConfiguration(
@@ -315,7 +315,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
                     config = config,
                     dependenciesBuilder = dependenciesBuilder,
                     rawBackendFiles = rawBackendFiles,
-                    adjuster = adjuster,
+                    adjusterFactory = adjusterFactory,
                 ),
             )
         }

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/FunctionalTestRunner.kt
@@ -131,7 +131,7 @@ abstract class FunctionalTestRunner<BACKEND : Backend<BACKEND>>(
         val backendOrganization = organizeBackends(
             listOf(backendId),
             lookupFactory = ::lookupFactory,
-            onMissingFactory = { error(it) },
+            onError = { error(it) },
         )
         // TODO Actually build by buckets?
         val outputRoot = OutputRoot(MemoryFileSystem())

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
@@ -103,6 +103,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
                 moduleResultNeeded = moduleResultNeeded,
                 logSink = logSink,
                 outputRoot = outputRoot,
+                adjuster = factory.adjusters()[backendId],
             )
         }
     }
@@ -117,6 +118,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
     moduleResultNeeded: Boolean,
     logSink: LogSink,
     outputRoot: OutputRoot,
+    adjuster: BackendAdjuster?,
     activeFactories: Iterable<Backend.Factory<*>> = listOf(factory),
 ) {
     val backendId = factory.backendId
@@ -197,6 +199,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
                     logSink,
                     NullDependencyResolver,
                     backendConfig,
+                    adjuster = adjuster,
                 ),
             )
         }

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
@@ -103,7 +103,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
                 moduleResultNeeded = moduleResultNeeded,
                 logSink = logSink,
                 outputRoot = outputRoot,
-                adjuster = factory.adjusters()[backendId],
+                adjusterFactory = factory.adjusterFactories()[backendId],
             )
         }
     }
@@ -118,7 +118,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
     moduleResultNeeded: Boolean,
     logSink: LogSink,
     outputRoot: OutputRoot,
-    adjuster: BackendAdjuster?,
+    adjusterFactory: BackendAdjusterFactory?,
     activeFactories: Iterable<Backend.Factory<*>> = listOf(factory),
 ) {
     val backendId = factory.backendId
@@ -199,7 +199,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
                     logSink,
                     NullDependencyResolver,
                     backendConfig,
-                    adjuster = adjuster,
+                    adjusterFactory = adjusterFactory,
                 ),
             )
         }

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
@@ -90,7 +90,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
     val backendOrganization = organizeBackends(
         listOf(factory.backendId),
         lookupFactory = lookupFactory,
-        onMissingFactory = { error(it) },
+        onError = { error(it) },
     )
     for (bucket in backendOrganization.backendBuckets) {
         for (backendId in bucket) {

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -109,6 +109,7 @@ abstract class Backend<SELF : Backend<SELF>>(
      */
     val dependenciesBuilder: Dependencies.Builder<SELF>,
     val rawBackendFiles: Map<FilePath, String> = mapOf(),
+    val adjuster: BackendAdjuster? = null,
 ) {
     constructor(backendId: BackendId, setup: BackendSetup<SELF>) : this(
         backendId = backendId,
@@ -121,6 +122,7 @@ abstract class Backend<SELF : Backend<SELF>>(
         config = setup.config,
         dependenciesBuilder = setup.dependenciesBuilder,
         rawBackendFiles = setup.rawBackendFiles,
+        adjuster = setup.adjuster,
     )
 
     val libraryConfigurations = dependenciesBuilder.libraryConfigurations
@@ -830,6 +832,12 @@ abstract class Backend<SELF : Backend<SELF>>(
          * [module list][BackendSetup.modules].
          */
         fun make(setup: BackendSetup<BACKEND>): Backend<BACKEND>
+
+        /**
+         * Adjuster by backend as wanted. Should only be given for backend ids
+         * in [BackendMeta.requiredBackendIds] for this backend.
+         */
+        fun adjusters(): Map<BackendId, BackendAdjuster> = mapOf()
     }
 
     @Retention(AnnotationRetention.RUNTIME)
@@ -898,7 +906,35 @@ data class BackendSetup<BACKEND : Backend<BACKEND>>(
     val config: Backend.Config,
     /** Files matching backend extensions from the library source tree. */
     val rawBackendFiles: Map<FilePath, String> = mapOf(),
+    val adjuster: BackendAdjuster? = null,
 )
+
+/**
+ * Adjusts, customized, or transforms backend behavior. Might be installed by
+ * one backend on another in some custom Temper configuration.
+ */
+interface BackendAdjuster {
+    /**
+     * Optionally customizes an already translated connected call. On null
+     * return value, use the original.
+     */
+    fun <T: OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+        return null
+    }
+
+    // TODO adjustModuleTree to be called on the final product???
+
+    // TODO addTranslations or addFiles to add more files.
+}
+
+/** Combines two adjusters with [this] as priority. */
+fun BackendAdjuster.orElse(other: BackendAdjuster): BackendAdjuster {
+    return object : BackendAdjuster {
+        override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+            return adjustConnectedCall(decl, call) ?: other.adjustConnectedCall(decl, call)
+        }
+    }
+}
 
 private fun sourceMapFile(outputSourceFile: FilePath): FilePath {
     check(outputSourceFile.isFile)
@@ -937,6 +973,9 @@ data class BackendOrganization(
 
     /** The factory for each backend. */
     val factoriesById: Map<BackendId, Backend.Factory<*>>,
+
+    /** Priority order rather than chain. */
+    val adjusters: Map<BackendId, BackendAdjuster> = mapOf(),
 )
 
 /** Calculate transitive backend organization as needed by the given initially requested [backendIds]. */
@@ -1009,9 +1048,20 @@ fun organizeBackends(
         }
     }
     val backendRequirements = transitiveClosure(backendOrderingFounds).mapValues { setOf(it.key) + it.value }
+    val adjusters = buildMap<BackendId, BackendAdjuster> {
+        for (factory in factoriesById.values) {
+            val adjusters = factory.adjusters()
+            for ((backendId, adjuster) in adjusters) {
+                compute(backendId) { _, previous ->
+                    previous?.let { previous.orElse(adjuster) } ?: adjuster
+                }
+            }
+        }
+    }
     return BackendOrganization(
         backendBuckets = backendBuckets,
         backendRequirements = backendRequirements,
         factoriesById = factoriesById,
+        adjusters = adjusters,
     )
 }

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -911,7 +911,7 @@ data class BackendSetup<BACKEND : Backend<BACKEND>>(
 
 /** Enables module-based lifetimes on individual [BackendAdjuster] instances. */
 interface BackendAdjusterFactory {
-    fun makeAdjuster(module: TmpL.Module): BackendAdjuster
+    fun makeAdjuster(module: TmpL.Module, translator: Any): BackendAdjuster
 }
 
 /**
@@ -943,9 +943,9 @@ interface BackendAdjuster {
 /** Combines two adjuster factories with [this] as priority. */
 fun BackendAdjusterFactory.orElse(other: BackendAdjusterFactory): BackendAdjusterFactory {
     return object : BackendAdjusterFactory {
-        override fun makeAdjuster(module: TmpL.Module): BackendAdjuster {
-            val a = this@orElse.makeAdjuster(module)
-            val b = other.makeAdjuster(module)
+        override fun makeAdjuster(module: TmpL.Module, translator: Any): BackendAdjuster {
+            val a = this@orElse.makeAdjuster(module, translator)
+            val b = other.makeAdjuster(module, translator)
             return object : BackendAdjuster {
                 /** Only lets the secondary adjuster apply if the first returns null. */
                 override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -931,11 +931,12 @@ interface BackendAdjuster {
     }
 
     /**
-     * Return any extra files that should be added to the output translation,
-     * where [T] depends on the backend being adjusted.
+     * Pass any already built files. Most common behavior would be to add more.
+     * The adjust may want to reference existing files and could technically
+     * modify them.
      */
-    fun <T: OutTree<*>> additionalFilesAfterTranslation(): Collection<T> {
-        return listOf()
+    fun <T: OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
+        // Do nothing by default.
     }
 }
 

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -947,8 +947,15 @@ fun BackendAdjusterFactory.orElse(other: BackendAdjusterFactory): BackendAdjuste
             val a = this@orElse.makeAdjuster(module)
             val b = other.makeAdjuster(module)
             return object : BackendAdjuster {
+                /** Only lets the secondary adjuster apply if the first returns null. */
                 override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
                     return a.adjustConnectedCall(decl, call) ?: b.adjustConnectedCall(decl, call)
+                }
+
+                /** Adjusts in reverse order, so the priority adjuster has the final say. */
+                override fun <T : OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
+                    b.adjustFilesAfterTranslation(files)
+                    a.adjustFilesAfterTranslation(files)
                 }
             }
         }

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -926,7 +926,7 @@ interface BackendAdjuster {
      * Adjusters should return null for any [T] they don't know how to handle
      * although typically this is well-defined for a particular backend.
      */
-    fun <T: OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+    fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
         return null
     }
 
@@ -935,7 +935,7 @@ interface BackendAdjuster {
      * The adjust may want to reference existing files and could technically
      * modify them.
      */
-    fun <T: OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
+    fun <T : OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
         // Do nothing by default.
     }
 }

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -109,7 +109,7 @@ abstract class Backend<SELF : Backend<SELF>>(
      */
     val dependenciesBuilder: Dependencies.Builder<SELF>,
     val rawBackendFiles: Map<FilePath, String> = mapOf(),
-    val adjuster: BackendAdjuster? = null,
+    val adjusterFactory: BackendAdjusterFactory? = null,
 ) {
     constructor(backendId: BackendId, setup: BackendSetup<SELF>) : this(
         backendId = backendId,
@@ -122,7 +122,7 @@ abstract class Backend<SELF : Backend<SELF>>(
         config = setup.config,
         dependenciesBuilder = setup.dependenciesBuilder,
         rawBackendFiles = setup.rawBackendFiles,
-        adjuster = setup.adjuster,
+        adjusterFactory = setup.adjusterFactory,
     )
 
     val libraryConfigurations = dependenciesBuilder.libraryConfigurations
@@ -837,7 +837,7 @@ abstract class Backend<SELF : Backend<SELF>>(
          * Adjuster by backend as wanted. Should only be given for backend ids
          * in [BackendMeta.requiredBackendIds] for this backend.
          */
-        fun adjusters(): Map<BackendId, BackendAdjuster> = mapOf()
+        fun adjusterFactories(): Map<BackendId, BackendAdjusterFactory> = mapOf()
     }
 
     @Retention(AnnotationRetention.RUNTIME)
@@ -906,8 +906,13 @@ data class BackendSetup<BACKEND : Backend<BACKEND>>(
     val config: Backend.Config,
     /** Files matching backend extensions from the library source tree. */
     val rawBackendFiles: Map<FilePath, String> = mapOf(),
-    val adjuster: BackendAdjuster? = null,
+    val adjusterFactory: BackendAdjusterFactory? = null,
 )
+
+/** Enables module-based lifetimes on individual [BackendAdjuster] instances. */
+interface BackendAdjusterFactory {
+    fun makeAdjuster(module: TmpL.Module): BackendAdjuster
+}
 
 /**
  * Adjusts, customized, or transforms backend behavior. Might be installed by
@@ -917,21 +922,34 @@ interface BackendAdjuster {
     /**
      * Optionally customizes an already translated connected call. On null
      * return value, use the original.
+     *
+     * Adjusters should return null for any [T] they don't know how to handle
+     * although typically this is well-defined for a particular backend.
      */
     fun <T: OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
         return null
     }
 
-    // TODO adjustModuleTree to be called on the final product???
-
-    // TODO addTranslations or addFiles to add more files.
+    /**
+     * Return any extra files that should be added to the output translation,
+     * where [T] depends on the backend being adjusted.
+     */
+    fun <T: OutTree<*>> additionalFilesAfterTranslation(): Collection<T> {
+        return listOf()
+    }
 }
 
-/** Combines two adjusters with [this] as priority. */
-fun BackendAdjuster.orElse(other: BackendAdjuster): BackendAdjuster {
-    return object : BackendAdjuster {
-        override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
-            return adjustConnectedCall(decl, call) ?: other.adjustConnectedCall(decl, call)
+/** Combines two adjuster factories with [this] as priority. */
+fun BackendAdjusterFactory.orElse(other: BackendAdjusterFactory): BackendAdjusterFactory {
+    return object : BackendAdjusterFactory {
+        override fun makeAdjuster(module: TmpL.Module): BackendAdjuster {
+            val a = this@orElse.makeAdjuster(module)
+            val b = other.makeAdjuster(module)
+            return object : BackendAdjuster {
+                override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+                    return a.adjustConnectedCall(decl, call) ?: b.adjustConnectedCall(decl, call)
+                }
+            }
         }
     }
 }
@@ -975,7 +993,7 @@ data class BackendOrganization(
     val factoriesById: Map<BackendId, Backend.Factory<*>>,
 
     /** Priority order rather than chain. */
-    val adjusters: Map<BackendId, BackendAdjuster> = mapOf(),
+    val adjusterFactories: Map<BackendId, BackendAdjusterFactory> = mapOf(),
 )
 
 data class BackendOrganizationError(
@@ -1073,9 +1091,9 @@ fun organizeBackends(
         }
     }
     val backendRequirements = transitiveClosure(backendOrderingFounds).mapValues { setOf(it.key) + it.value }
-    val adjusters = buildMap<BackendId, BackendAdjuster> {
+    val adjusterFactories = buildMap<BackendId, BackendAdjusterFactory> {
         for (factory in factoriesById.values) {
-            val adjusters = factory.adjusters()
+            val adjusters = factory.adjusterFactories()
             val requiredBackendIds = factory.backendMeta.requiredBackendIds
             for ((backendId, adjuster) in adjusters) {
                 if (backendId !in requiredBackendIds) {
@@ -1095,6 +1113,6 @@ fun organizeBackends(
         backendBuckets = backendBuckets,
         backendRequirements = backendRequirements,
         factoriesById = factoriesById,
-        adjusters = adjusters,
+        adjusterFactories = adjusterFactories,
     )
 }

--- a/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/Backend.kt
@@ -978,11 +978,33 @@ data class BackendOrganization(
     val adjusters: Map<BackendId, BackendAdjuster> = mapOf(),
 )
 
+data class BackendOrganizationError(
+    val kind: BackendOrganizationErrorKind,
+    val backendId: BackendId,
+    val sourceBackendId: BackendId? = null,
+)
+
+enum class BackendOrganizationErrorKind {
+    /**
+     * A factory was missing for some requested [BackendId], whether in the
+     * initial list or as some listed, transitive requirement of one.
+     */
+    FactoryNotFound,
+
+    /**
+     * Required backends currently are in [BackendMeta.requiredBackendIds],
+     * which really only can express basic metadata, not things like adjusters.
+     * So adjusters are defined on the factory, but they are expected to be
+     * specified only for directly required backends.
+     */
+    AdjusterForUnrequiredBackend,
+}
+
 /** Calculate transitive backend organization as needed by the given initially requested [backendIds]. */
 fun organizeBackends(
     backendIds: Iterable<BackendId>,
     lookupFactory: (BackendId) -> Backend.Factory<*>?,
-    onMissingFactory: (BackendId) -> Unit,
+    onError: (BackendOrganizationError) -> Unit,
 ): BackendOrganization {
     // We need to order how we drive backends.
     // A backend for one target language might require translations for another target language.
@@ -998,7 +1020,10 @@ fun organizeBackends(
         fun factoryFor(backendId: BackendId) = factories.getOrPut(backendId) {
             lookupFactory(backendId).also { factory ->
                 if (factory == null) {
-                    onMissingFactory(backendId)
+                    BackendOrganizationError(
+                        kind = BackendOrganizationErrorKind.FactoryNotFound,
+                        backendId = backendId,
+                    ).also { onError(it) }
                 } else {
                     backendOrdering[backendId] = factory.backendMeta.requiredBackendIds.toSet()
                 }
@@ -1051,7 +1076,15 @@ fun organizeBackends(
     val adjusters = buildMap<BackendId, BackendAdjuster> {
         for (factory in factoriesById.values) {
             val adjusters = factory.adjusters()
+            val requiredBackendIds = factory.backendMeta.requiredBackendIds
             for ((backendId, adjuster) in adjusters) {
+                if (backendId !in requiredBackendIds) {
+                    BackendOrganizationError(
+                        kind = BackendOrganizationErrorKind.AdjusterForUnrequiredBackend,
+                        backendId = backendId,
+                        sourceBackendId = factory.backendId,
+                    ).also { onError(it) }
+                }
                 compute(backendId) { _, previous ->
                     previous?.let { previous.orElse(adjuster) } ?: adjuster
                 }

--- a/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLHelpers.kt
+++ b/be/src/commonMain/kotlin/lang/temper/be/tmpl/TmpLHelpers.kt
@@ -247,7 +247,7 @@ fun TmpL.FunctionDeclaration.parameterDefaultStatementsInfo(): DefaultStatements
     // This includes being a lazy decision after we know that a backend wants this info.
     // Here we expect each optional to have an if statement mentioning it and an assignment inside.
     val defaultStatements = mutableListOf<TmpL.Statement>()
-    val parameterMapping = buildMap parameterMapping@{
+    val parameterMapping = buildMap parameterMapping@{ // TODO If nullable with default null, what happens here?
         parameters@ for (parameter in parameters.parameters) {
             // Start out with original names, but replace them later.
             if (parameter.optional) {

--- a/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
@@ -1,5 +1,6 @@
 package lang.temper.be
 
+import lang.temper.ast.OutTree
 import lang.temper.be.tmpl.TestBackend
 import lang.temper.be.tmpl.TmpL
 import lang.temper.lexer.defaultClassifyTemperSource
@@ -7,18 +8,68 @@ import lang.temper.library.LibraryConfiguration
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.name.BackendId
+import lang.temper.name.BuiltinName
 import lang.temper.name.DashedIdentifier
 import lang.temper.name.ModuleName
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 class BackendTest {
-    private val helloWorldLibraryConfig = LibraryConfiguration(
-        libraryName = DashedIdentifier.from("hello-world")!!,
-        libraryRoot = dirPath("a"),
-        supportedBackendList = emptyList(),
-        classifyTemperSource = ::defaultClassifyTemperSource,
-    )
+    @Test
+    fun backendAdjusters() {
+        val tmpl = TmplGenerator(".test")
+        // Define some adjusters and factories.
+        class TestAdjusterA : BackendAdjuster {
+            override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+                // Abusively just treat ids as calls to simplify.
+                call is TmpL.Id || return null
+                return when (call.name.displayName) {
+                    "_" -> {
+                        @Suppress("UNCHECKED_CAST")
+                        return tmpl.makeId(BuiltinName("there")) as T
+                    }
+                    else -> null
+                }
+            }
+            override fun <T : OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
+                @Suppress("UNCHECKED_CAST")
+                files.add(tmpl.makeId(BuiltinName("a")) as T)
+            }
+        }
+        class TestAdjusterB : BackendAdjuster {
+            override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {
+                return call
+            }
+            override fun <T : OutTree<*>> adjustFilesAfterTranslation(files: MutableList<T>) {
+                @Suppress("UNCHECKED_CAST")
+                files.add(tmpl.makeId(BuiltinName("b")) as T)
+            }
+        }
+        class TestAdjusterFactory(val adjuster: BackendAdjuster) : BackendAdjusterFactory {
+            override fun makeAdjuster(module: TmpL.Module): BackendAdjuster = adjuster
+        }
+        val comboFactory = TestAdjusterFactory(TestAdjusterA())
+            .orElse(TestAdjusterFactory(TestAdjusterB()))
+        // Work on some tmpl.
+        val module = tmpl.module {
+            moduleFunction(BuiltinName("hi")) {}
+        }
+        val adjuster = comboFactory.makeAdjuster(module)
+        val function = module.topLevels.first() as TmpL.FunctionDeclaration
+        fun adjustCall(name: String): String {
+            val id = adjuster.adjustConnectedCall(function, tmpl.makeId(BuiltinName(name)))
+            return id!!.name.displayName
+        }
+        // The first adjuster only replaces name "_". The second always returns what it's given.
+        assertEquals("there", adjustCall("_"))
+        assertEquals("yall", adjustCall("yall"))
+        // Now see how we finalize, expecting reverse order.
+        assertContentEquals(
+            listOf("b", "a"),
+            buildList<TmpL.Id> { adjuster.adjustFilesAfterTranslation(this) }.map { it.name.displayName },
+        )
+    }
 
     @Test
     fun backendOrganization() {
@@ -163,4 +214,11 @@ class BackendTest {
             Backend.defaultFilePathForSource(helloWorldLibraryConfig, moduleName, ".out"),
         )
     }
+
+    private val helloWorldLibraryConfig = LibraryConfiguration(
+        libraryName = DashedIdentifier.from("hello-world")!!,
+        libraryRoot = dirPath("a"),
+        supportedBackendList = emptyList(),
+        classifyTemperSource = ::defaultClassifyTemperSource,
+    )
 }

--- a/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
@@ -21,19 +21,32 @@ class BackendTest {
 
     @Test
     fun backendOrganization() {
-        class NeedyBackendFactory(backendId: String, requiredBackendIds: List<BackendId>) : TestBackend.TestFactory() {
+        class NeedyBackendFactory(
+            backendId: String,
+            requiredBackendIds: List<BackendId>,
+            val adjusters: Map<BackendId, BackendAdjuster> = mapOf(),
+        ) : TestBackend.TestFactory() {
             override val backendId: BackendId = BackendId(backendId)
             override val backendMeta = super.backendMeta.copy(
                 backendId = this.backendId,
                 requiredBackendIds = requiredBackendIds,
             )
+            override fun adjusters(): Map<BackendId, BackendAdjuster> {
+                return adjusters
+            }
         }
         val missingBackendId = BackendId("missing")
         val needyFactory = NeedyBackendFactory("needy", listOf(TestBackend.backendId, missingBackendId))
         val needlessFactory = NeedyBackendFactory("needless", listOf())
+        val uselessAdjuster = object : BackendAdjuster {}
         val needierFactory = NeedyBackendFactory(
-            "needier",
-            listOf(needyFactory.backendId, needlessFactory.backendId),
+            backendId = "needier",
+            requiredBackendIds = listOf(needyFactory.backendId, needlessFactory.backendId),
+            adjusters = mapOf(
+                needyFactory.backendId to uselessAdjuster,
+                // We don't directly require this, so we shouldn't be adjusting it.
+                TestBackend.backendId to uselessAdjuster,
+            ),
         )
         val aloofBackend = NeedyBackendFactory("aloof", listOf())
         val requestedAloofFactory = NeedyBackendFactory("requested-aloof", listOf())
@@ -45,14 +58,27 @@ class BackendTest {
             aloofBackend,
             requestedAloofFactory,
         ).associateBy { it.backendId }
-        val missingBackendIds = mutableSetOf<BackendId>()
+        val errors = mutableSetOf<BackendOrganizationError>()
         val organization = organizeBackends(
             backendIds = listOf(needierFactory.backendMeta.backendId, requestedAloofFactory.backendId),
             lookupFactory = { backends[it] },
-            onMissingFactory = { missingBackendIds.add(it) },
+            onError = { err -> errors.add(err) },
         )
-        assertEquals(setOf(missingBackendId), missingBackendIds)
         // Collections maintain order by default, so these should be reliable.
+        assertEquals(
+            setOf(
+                BackendOrganizationError(
+                    kind = BackendOrganizationErrorKind.FactoryNotFound,
+                    backendId = missingBackendId,
+                ),
+                BackendOrganizationError(
+                    kind = BackendOrganizationErrorKind.AdjusterForUnrequiredBackend,
+                    backendId = TestBackend.backendId,
+                    sourceBackendId = needierFactory.backendId,
+                ),
+            ),
+            errors,
+        )
         assertEquals(
             mapOf(
                 needierFactory.backendId to setOf(
@@ -77,6 +103,7 @@ class BackendTest {
             organization.backendBuckets,
         )
         assertEquals(backends.keys - setOf(aloofBackend.backendId), organization.factoriesById.keys)
+        assertEquals(uselessAdjuster, organization.adjusters[needyFactory.backendId])
     }
 
     @Test

--- a/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
@@ -19,6 +19,7 @@ class BackendTest {
     @Test
     fun backendAdjusters() {
         val tmpl = TmplGenerator(".test")
+
         // Define some adjusters and factories.
         class TestAdjusterA : BackendAdjuster {
             override fun <T : OutTree<*>> adjustConnectedCall(decl: TmpL.FunctionDeclaration, call: T): T? {

--- a/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
@@ -1,6 +1,7 @@
 package lang.temper.be
 
 import lang.temper.be.tmpl.TestBackend
+import lang.temper.be.tmpl.TmpL
 import lang.temper.lexer.defaultClassifyTemperSource
 import lang.temper.library.LibraryConfiguration
 import lang.temper.log.dirPath
@@ -24,28 +25,31 @@ class BackendTest {
         class NeedyBackendFactory(
             backendId: String,
             requiredBackendIds: List<BackendId>,
-            val adjusters: Map<BackendId, BackendAdjuster> = mapOf(),
+            val adjusterFactories: Map<BackendId, BackendAdjusterFactory> = mapOf(),
         ) : TestBackend.TestFactory() {
             override val backendId: BackendId = BackendId(backendId)
             override val backendMeta = super.backendMeta.copy(
                 backendId = this.backendId,
                 requiredBackendIds = requiredBackendIds,
             )
-            override fun adjusters(): Map<BackendId, BackendAdjuster> {
-                return adjusters
+            override fun adjusterFactories(): Map<BackendId, BackendAdjusterFactory> {
+                return adjusterFactories
             }
         }
         val missingBackendId = BackendId("missing")
         val needyFactory = NeedyBackendFactory("needy", listOf(TestBackend.backendId, missingBackendId))
         val needlessFactory = NeedyBackendFactory("needless", listOf())
         val uselessAdjuster = object : BackendAdjuster {}
+        val uselessAdjusterFactory = object : BackendAdjusterFactory {
+            override fun makeAdjuster(module: TmpL.Module): BackendAdjuster = uselessAdjuster
+        }
         val needierFactory = NeedyBackendFactory(
             backendId = "needier",
             requiredBackendIds = listOf(needyFactory.backendId, needlessFactory.backendId),
-            adjusters = mapOf(
-                needyFactory.backendId to uselessAdjuster,
+            adjusterFactories = mapOf(
+                needyFactory.backendId to uselessAdjusterFactory,
                 // We don't directly require this, so we shouldn't be adjusting it.
-                TestBackend.backendId to uselessAdjuster,
+                TestBackend.backendId to uselessAdjusterFactory,
             ),
         )
         val aloofBackend = NeedyBackendFactory("aloof", listOf())
@@ -103,7 +107,7 @@ class BackendTest {
             organization.backendBuckets,
         )
         assertEquals(backends.keys - setOf(aloofBackend.backendId), organization.factoriesById.keys)
-        assertEquals(uselessAdjuster, organization.adjusters[needyFactory.backendId])
+        assertEquals(uselessAdjusterFactory, organization.adjusterFactories[needyFactory.backendId])
     }
 
     @Test

--- a/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/BackendTest.kt
@@ -47,7 +47,7 @@ class BackendTest {
             }
         }
         class TestAdjusterFactory(val adjuster: BackendAdjuster) : BackendAdjusterFactory {
-            override fun makeAdjuster(module: TmpL.Module): BackendAdjuster = adjuster
+            override fun makeAdjuster(module: TmpL.Module, translator: Any): BackendAdjuster = adjuster
         }
         val comboFactory = TestAdjusterFactory(TestAdjusterA())
             .orElse(TestAdjusterFactory(TestAdjusterB()))
@@ -55,7 +55,7 @@ class BackendTest {
         val module = tmpl.module {
             moduleFunction(BuiltinName("hi")) {}
         }
-        val adjuster = comboFactory.makeAdjuster(module)
+        val adjuster = comboFactory.makeAdjuster(module, Unit)
         val function = module.topLevels.first() as TmpL.FunctionDeclaration
         fun adjustCall(name: String): String {
             val id = adjuster.adjustConnectedCall(function, tmpl.makeId(BuiltinName(name)))
@@ -92,7 +92,7 @@ class BackendTest {
         val needlessFactory = NeedyBackendFactory("needless", listOf())
         val uselessAdjuster = object : BackendAdjuster {}
         val uselessAdjusterFactory = object : BackendAdjusterFactory {
-            override fun makeAdjuster(module: TmpL.Module): BackendAdjuster = uselessAdjuster
+            override fun makeAdjuster(module: TmpL.Module, translator: Any): BackendAdjuster = uselessAdjuster
         }
         val needierFactory = NeedyBackendFactory(
             backendId = "needier",

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -430,7 +430,7 @@ fun doOneBuild(build: Build): BuildResult {
                     logSink = projectLogSink,
                     dependencyResolver = dependencyResolver,
                     config = harness.backendConfig,
-                    adjuster = backendOrganization.adjusters[factory.backendId],
+                    adjusterFactory = backendOrganization.adjusterFactories[factory.backendId],
                 ),
             )
         }

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -384,13 +384,15 @@ fun doOneBuild(build: Build): BuildResult {
     val backendOrganization = organizeBackends(
         backendIds = libraries.flatMap { it.first.supportedBackendList }.toSet(),
         lookupFactory = ::lookupFactory,
-        onMissingFactory = { backendId ->
-            if (backendId != interpBackendId) {
+        onError = { err ->
+            if (err.backendId != interpBackendId) {
+                // Ignore error kind for now, but that might be nice to add in the future.
+                // These errors should be rare.
                 projectLogSink.log(
                     Log.Error,
                     MessageTemplate.BadBackend,
                     unknownPos,
-                    listOf(backendId),
+                    listOf(err.backendId),
                 )
             }
         },

--- a/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
+++ b/tooling/src/commonMain/kotlin/lang/temper/tooling/buildrun/Build.kt
@@ -428,6 +428,7 @@ fun doOneBuild(build: Build): BuildResult {
                     logSink = projectLogSink,
                     dependencyResolver = dependencyResolver,
                     config = harness.backendConfig,
+                    adjuster = backendOrganization.adjusters[factory.backendId],
                 ),
             )
         }


### PR DESCRIPTION
- Allow a backend that requires another also to conditionally intercept handling of connected calls
- Report an error when adding an adjuster for a backend not mentioned as required
- Register required backends separately from adjuster factories because required backend ids are in BackendMeta, which is a more limited context, and maybe that's ok
- Process this per module, allowing the adjuster to add extra output to a module, for example
- Type safety isn't forced here; adjust implementers have to be careful
- Also implement adjustment specifically in be-java, and no others so far except unit test backends, for use from a separate repo
- Also add a couple of small things in support of external repo needs