### PR TITLE
Backend test connected code

### DIFF
--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppBackend.kt
@@ -135,10 +135,10 @@ class CppBackend private constructor(
 
         // Connected code.
         val connectedFiles = buildList {
+            val rootSize = libraryConfigurations.currentLibraryConfiguration.libraryRoot.segments.size
             for (file in rawBackendFiles) {
                 MetadataFileSpecification(
-                    // Skip the library name part.
-                    path = file.key.segments.subListToEnd(1).asFilePath(),
+                    path = file.key.segments.subListToEnd(rootSize).asFilePath(),
                     mimeType = MimeType.cppSource,
                     content = file.value,
                 ).also { add(it) }

--- a/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
+++ b/be-cpp/src/commonMain/kotlin/lang/temper/be/cpp/CppTranslator.kt
@@ -3361,7 +3361,13 @@ class CppTranslator(
                         buildList {
                             add(cpp.include("$modPath$hppName"))
                             if (hasConnected) {
-                                add(cpp.includeLocal("_connected.hpp"))
+                                val connectedIncludePath = "_connected.hpp".let { connectedIncludeName ->
+                                    when {
+                                        relPath.segments.isEmpty() -> connectedIncludeName
+                                        else -> "$moduleBaseName/$connectedIncludeName"
+                                    }
+                                }
+                                add(cpp.includeLocal(connectedIncludePath))
                             }
                             addAll(namespaced(implVarDecls + impl))
                         },

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -9,6 +9,7 @@ import lang.temper.lexer.Genre
 import lang.temper.log.filePath
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.text.trimMargin
 
 @SuppressWarnings("MaxLineLength")
 class CppBackendTest {
@@ -643,6 +644,148 @@ class CppBackendTest {
                 "void set_value(int32_t)",
                 "setBox",
             ),
+        )
+    }
+
+    @Test
+    fun connected() {
+        val connecteds = listOf(
+            filePath("something", "_connected.cpp") to """
+                    |#include "_connected.hpp"
+                    |#include "support.hpp"
+                    |
+                    |namespace work {
+                    |namespace _connected {
+                    |
+                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus) {
+                    |    return i + j + bonus;
+                    |}
+                    |
+                    |} // namespace _connected
+                    |} // namespace work
+                """.trimMargin(),
+            filePath("something", "_connected.hpp") to """
+                    |#pragma once
+                    |
+                    |#include <cstdint>
+                    |#include <work/init.hpp>
+                    |
+                    |namespace work {
+                    |namespace _connected {
+                    |
+                    |using namespace work;
+                    |
+                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus);
+                    |
+                    |} // namespace _connected
+                    |} // namespace work
+                """.trimMargin(),
+            filePath("other", "thing", "whatever.cpp") to """
+                    |// Content doesn't really matter here.
+                """.trimMargin(),
+        )
+        assertGeneratedCode(
+            backendConfig = Backend.Config.production,
+            factory = CppBackend.Cpp,
+            inputs = listOf(
+                filePath("something", "fun.temper") to """
+                    |let { prod } = import("./deeper");
+                    |
+                    |@connected
+                    |export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                    |
+                    |export let inc(i: Int): Int {
+                    |    sum(i, 1)
+                    |}
+                    |
+                    |export let twice(i: Int): Int {
+                    |  prod(i, 2)
+                    |}
+                """.trimMargin(),
+                filePath("something", "deeper", "more-fun.temper") to """
+                    |export let prod(i: Int, j: Int): Int {
+                    |    i * j
+                    |}
+                """.trimMargin(),
+            ) + connecteds,
+            want = """
+                |{
+                |    "cpp": {
+                |        "my-test-library": {
+                |            "something.cpp": {
+                |                content: ```
+                |                  #include <my-test-library/something.hpp>
+                |                  #include "something/_connected.hpp"
+                |                  namespace my_test_library {
+                |                    int32_t sum(int32_t i_4, int32_t j_5, temper::core::NullableParam<int32_t> bonus) {
+                |                      int32_t bonus_6;
+                |                      if(temper::core::is_null(bonus)) {
+                |                        {
+                |                          bonus_6 = 0;
+                |                        }
+                |                      }else {
+                |                        {
+                |                          bonus_6 = temper::core::not_null(bonus);
+                |                        }
+                |                      }
+                |                      return _connected::sum(i_4, j_5, bonus_6);
+                |                    }
+                |                    int32_t sum(int32_t i_4, int32_t j_5) {
+                |                      return sum(i_4, j_5, nullptr);
+                |                    }
+                |                    int32_t inc(int32_t i_8) {
+                |                      return sum(i_8, 1);
+                |                    }
+                |                    int32_t twice(int32_t i_10) {
+                |                      return my_test_library::prod(i_10, 2);
+                |                    }
+                |                    void global_init_something() {
+                |                      static bool initialized = false;
+                |                      if(initialized) {
+                |                        return;
+                |                      }
+                |                      initialized = true;
+                |                      my_test_library::global_init_deeper();
+                |                    }
+                |                  }
+                |
+                |                  ```
+                |            },
+                |            "something.hpp": {
+                |                "content": ```
+                |                  #pragma once
+                |                  #include <temper-core/core.hpp>
+                |                  #include <my-test-library/something/deeper.hpp>
+                |                  namespace my_test_library {
+                |                    int32_t sum(int32_t, int32_t, temper::core::NullableParam<int32_t>);
+                |                    int32_t sum(int32_t, int32_t);
+                |                    int32_t inc(int32_t);
+                |                    int32_t twice(int32_t);
+                |                    void global_init_something();
+                |                  }
+                |
+                |                  ```
+                |            },
+                |            "something": {
+                |                "_connected.cpp": "__DO_NOT_CARE__",
+                |                "_connected.hpp": "__DO_NOT_CARE__",
+                |                "deeper.cpp": "__DO_NOT_CARE__",
+                |                "deeper.hpp": "__DO_NOT_CARE__",
+                |                "deeper.hpp.map": "__DO_NOT_CARE__",
+                |                "deeper.cpp.map": "__DO_NOT_CARE__",
+                |            },
+                |            "something.cpp.map": "__DO_NOT_CARE__",
+                |            "something.hpp.map": "__DO_NOT_CARE__",
+                |            "main.cpp": "__DO_NOT_CARE__",
+                |            "other": {
+                |                "thing": {
+                |                    "whatever.cpp": "__DO_NOT_CARE__",
+                |                },
+                |            },
+                |        },
+                |    },
+                |}
+            """.trimMargin(),
         )
     }
 }

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -4,6 +4,7 @@ import lang.temper.be.Backend
 import lang.temper.be.assertGeneratedCode
 import lang.temper.be.generateCode
 import lang.temper.common.ListBackedLogSink
+import lang.temper.common.stripDoubleHashCommentLinesToPutCommentsInlineBelow
 import lang.temper.fs.MemoryFileSystem
 import lang.temper.lexer.Genre
 import lang.temper.log.filePath
@@ -653,6 +654,7 @@ class CppBackendTest {
             backendConfig = Backend.Config.production,
             factory = CppBackend.Cpp,
             inputs = listOf(
+                // Test using a submodule.
                 filePath("something", "fun.temper") to """
                     |let { prod } = import("./deeper");
                     |export let twice(i: Int): Int {
@@ -670,6 +672,7 @@ class CppBackendTest {
                     |    i * j
                     |}
                 """.trimMargin(),
+                // Connected code needs explicit cpp and hpp files and explicit namespaces inside.
                 filePath("something", "_connected.cpp") to """
                     |#include "_connected.hpp"
                     |
@@ -707,6 +710,7 @@ class CppBackendTest {
                 |{
                 |    "cpp": {
                 |        "my-test-library": {
+                |## Submodule something gets translated for now as "something.cpp|hpp".
                 |            "something.cpp": {
                 |                content: ```
                 |                  #include <my-test-library/something.hpp>
@@ -761,6 +765,7 @@ class CppBackendTest {
                 |
                 |                  ```
                 |            },
+                |## Other submodule content goes in a "something" subdir but retains the namespace given.
                 |            "something": {
                 |                "_connected.cpp": "__DO_NOT_CARE__",
                 |                "_connected.hpp": "__DO_NOT_CARE__",
@@ -780,7 +785,7 @@ class CppBackendTest {
                 |        },
                 |    },
                 |}
-            """.trimMargin(),
+            """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
         )
     }
 }

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -655,16 +655,14 @@ class CppBackendTest {
             inputs = listOf(
                 filePath("something", "fun.temper") to """
                     |let { prod } = import("./deeper");
+                    |export let twice(i: Int): Int {
+                    |  prod(i, 2)
+                    |}
                     |
                     |@connected
                     |export let sum(i: Int, j: Int, bonus: Int = 0): Int;
-                    |
                     |export let inc(i: Int): Int {
                     |    sum(i, 1)
-                    |}
-                    |
-                    |export let twice(i: Int): Int {
-                    |  prod(i, 2)
                     |}
                 """.trimMargin(),
                 filePath("something", "deeper", "more-fun.temper") to """
@@ -674,7 +672,6 @@ class CppBackendTest {
                 """.trimMargin(),
                 filePath("something", "_connected.cpp") to """
                     |#include "_connected.hpp"
-                    |#include "support.hpp"
                     |
                     |namespace work {
                     |namespace _connected {
@@ -690,7 +687,7 @@ class CppBackendTest {
                     |#pragma once
                     |
                     |#include <cstdint>
-                    |#include <work/init.hpp>
+                    |#include <my-test-library/something.hpp>
                     |
                     |namespace work {
                     |namespace _connected {
@@ -715,27 +712,27 @@ class CppBackendTest {
                 |                  #include <my-test-library/something.hpp>
                 |                  #include "something/_connected.hpp"
                 |                  namespace my_test_library {
-                |                    int32_t sum(int32_t i_4, int32_t j_5, temper::core::NullableParam<int32_t> bonus) {
-                |                      int32_t bonus_6;
+                |                    int32_t twice(int32_t i_4) {
+                |                      return my_test_library::prod(i_4, 2);
+                |                    }
+                |                    int32_t sum(int32_t i_6, int32_t j_7, temper::core::NullableParam<int32_t> bonus) {
+                |                      int32_t bonus_8;
                 |                      if(temper::core::is_null(bonus)) {
                 |                        {
-                |                          bonus_6 = 0;
+                |                          bonus_8 = 0;
                 |                        }
                 |                      }else {
                 |                        {
-                |                          bonus_6 = temper::core::not_null(bonus);
+                |                          bonus_8 = temper::core::not_null(bonus);
                 |                        }
                 |                      }
-                |                      return _connected::sum(i_4, j_5, bonus_6);
+                |                      return _connected::sum(i_6, j_7, bonus_8);
                 |                    }
-                |                    int32_t sum(int32_t i_4, int32_t j_5) {
-                |                      return sum(i_4, j_5, nullptr);
+                |                    int32_t sum(int32_t i_6, int32_t j_7) {
+                |                      return sum(i_6, j_7, nullptr);
                 |                    }
-                |                    int32_t inc(int32_t i_8) {
-                |                      return sum(i_8, 1);
-                |                    }
-                |                    int32_t twice(int32_t i_10) {
-                |                      return my_test_library::prod(i_10, 2);
+                |                    int32_t inc(int32_t i_10) {
+                |                      return sum(i_10, 1);
                 |                    }
                 |                    void global_init_something() {
                 |                      static bool initialized = false;
@@ -755,10 +752,10 @@ class CppBackendTest {
                 |                  #include <temper-core/core.hpp>
                 |                  #include <my-test-library/something/deeper.hpp>
                 |                  namespace my_test_library {
+                |                    int32_t twice(int32_t);
                 |                    int32_t sum(int32_t, int32_t, temper::core::NullableParam<int32_t>);
                 |                    int32_t sum(int32_t, int32_t);
                 |                    int32_t inc(int32_t);
-                |                    int32_t twice(int32_t);
                 |                    void global_init_something();
                 |                  }
                 |

--- a/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
+++ b/be-cpp/src/commonTest/kotlin/lang/temper/be/cpp/CppBackendTest.kt
@@ -649,41 +649,6 @@ class CppBackendTest {
 
     @Test
     fun connected() {
-        val connecteds = listOf(
-            filePath("something", "_connected.cpp") to """
-                    |#include "_connected.hpp"
-                    |#include "support.hpp"
-                    |
-                    |namespace work {
-                    |namespace _connected {
-                    |
-                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus) {
-                    |    return i + j + bonus;
-                    |}
-                    |
-                    |} // namespace _connected
-                    |} // namespace work
-                """.trimMargin(),
-            filePath("something", "_connected.hpp") to """
-                    |#pragma once
-                    |
-                    |#include <cstdint>
-                    |#include <work/init.hpp>
-                    |
-                    |namespace work {
-                    |namespace _connected {
-                    |
-                    |using namespace work;
-                    |
-                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus);
-                    |
-                    |} // namespace _connected
-                    |} // namespace work
-                """.trimMargin(),
-            filePath("other", "thing", "whatever.cpp") to """
-                    |// Content doesn't really matter here.
-                """.trimMargin(),
-        )
         assertGeneratedCode(
             backendConfig = Backend.Config.production,
             factory = CppBackend.Cpp,
@@ -707,7 +672,40 @@ class CppBackendTest {
                     |    i * j
                     |}
                 """.trimMargin(),
-            ) + connecteds,
+                filePath("something", "_connected.cpp") to """
+                    |#include "_connected.hpp"
+                    |#include "support.hpp"
+                    |
+                    |namespace work {
+                    |namespace _connected {
+                    |
+                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus) {
+                    |    return i + j + bonus;
+                    |}
+                    |
+                    |} // namespace _connected
+                    |} // namespace work
+                """.trimMargin(),
+                filePath("something", "_connected.hpp") to """
+                    |#pragma once
+                    |
+                    |#include <cstdint>
+                    |#include <work/init.hpp>
+                    |
+                    |namespace work {
+                    |namespace _connected {
+                    |
+                    |using namespace work;
+                    |
+                    |std::int32_t sum(std::int32_t i, std::int32_t j, std::int32_t bonus);
+                    |
+                    |} // namespace _connected
+                    |} // namespace work
+                """.trimMargin(),
+                filePath("other", "thing", "whatever.cpp") to """
+                    |// Content doesn't really matter here.
+                """.trimMargin(),
+            ),
             want = """
                 |{
                 |    "cpp": {

--- a/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpBackend.kt
+++ b/be-csharp/src/commonMain/kotlin/lang/temper/be/csharp/CSharpBackend.kt
@@ -186,9 +186,10 @@ class CSharpBackend(setup: BackendSetup<CSharpBackend>) : Backend<CSharpBackend>
                 }
             }
             // Connected source.
+            val rootSize = libraryConfig.libraryRoot.segments.size
             for (file in rawBackendFiles) {
                 // Skip the library name dir and the file name, and keep the middle
-                val subspace = chooseSubspace(file.key.segments).subList(1, file.key.segments.size - 1)
+                val subspace = chooseSubspace(file.key.segments).subList(rootSize, file.key.segments.size - 1)
                 MetadataFileSpecification(
                     path = dirPath(SRC_PROJECT_DIR).resolve(dirPath(subspace)).resolveFile(file.key.segments.last()),
                     mimeType = mimeType,

--- a/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
+++ b/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
@@ -1530,7 +1530,7 @@ class CSharpBackendTest {
                     |    }
                     |}
                 """.trimMargin(),
-            filePath("other", "thing", "Helper.cs") to """
+            filePath("other", "thing", "Whatever.cs") to """
                     |namespace MyTestLibrary.Other.Thing
                     |{
                     |    static class Whatever

--- a/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
+++ b/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
@@ -1506,6 +1506,7 @@ class CSharpBackendTest {
     @Test
     fun connected() = run {
         val connecteds = listOf(
+            // Connected code needs explicit namespaces inside.
             filePath("test", "TestConnected.cs") to """
                     |namespace MyTestLibrary.Test
                     |{
@@ -1542,10 +1543,10 @@ class CSharpBackendTest {
         )
         assertGenerateWanted(
             inputs = listOf(
+                // Test using a submodule.
                 filePath("test", "rand.temper") to """
                     |@connected
                     |export let sum(i: Int, j: Int, bonus: Int = 0): Int;
-                    |
                     |export let inc(i: Int): Int {
                     |    sum(i, 1)
                     |}
@@ -1583,6 +1584,8 @@ class CSharpBackendTest {
                 ),
             ),
             outputs = connecteds.map { (filePath, content) ->
+                // Automatically place files we expect to copy over.
+                // They go in same namespace dirs here as translated code.
                 val segments = buildList {
                     addAll(chooseSubspace(filePath.segments.subList(0, filePath.segments.size - 1)))
                     add(filePath.segments.last().fullName)

--- a/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
+++ b/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
@@ -5,9 +5,13 @@ import lang.temper.be.assertGeneratedCode
 import lang.temper.be.inputFileMapFromJson
 import lang.temper.common.stripDoubleHashCommentLinesToPutCommentsInlineBelow
 import lang.temper.common.structure.FormattingStructureSink
+import lang.temper.common.structure.PropertySink
 import lang.temper.common.structure.StructureSink
 import lang.temper.common.structure.Structured
+import lang.temper.fs.FileClassification
+import lang.temper.fs.MemoryFileSystem
 import lang.temper.log.FilePath
+import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import kotlin.test.Test
 
@@ -540,15 +544,15 @@ class CSharpBackendTest {
     @Test
     fun userClass() {
         assertGeneratedUserClass(
-            temper = """
+            temper = $$"""
                 |export class Test(public var name: String) {
                 |  // Custom getter is nice for contrast with automated sometimes.
                 |  public get that(): String { thing() }
                 |  public thing(): String {
-                |    punctuate("Hi, ${"$"}{name}")
+                |    punctuate("Hi, ${name}")
                 |  }
                 |  private punctuate(message: String): String {
-                |    "${"$"}{message}!"
+                |    "${message}!"
                 |  }
                 |}
             """.trimMargin(),
@@ -596,9 +600,9 @@ class CSharpBackendTest {
     fun optionals() {
         // Compare optionals for value and reference types, including a side effect for motivation.
         assertGeneratedGlobalClass(
-            temper = """
+            temper = $$"""
                 |let hi(i: Int = do { console.log("heh"); 1 }): Int { i + 1 }
-                |export let ha(s: String = "hum"): String { hi(); "${"$"}{s}bug" }
+                |export let ha(s: String = "hum"): String { hi(); "${s}bug" }
             """.trimMargin(),
             usings = """
                 |using S = MyTestLibrary.Support;
@@ -1498,6 +1502,95 @@ class CSharpBackendTest {
             |}
         """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )
+
+    @Test
+    fun connected() = run {
+        val connecteds = listOf(
+            filePath("test", "TestConnected.cs") to """
+                    |namespace MyTestLibrary.Test
+                    |{
+                    |    static class TestConnected
+                    |    {
+                    |        static int sum(int i, int j, int bonus)
+                    |        {
+                    |            return Helper.sum2(Helper.sum2(i, j), bonus);
+                    |        }
+                    |    }
+                    |}
+                """.trimMargin(),
+            filePath("test", "Helper.cs") to """
+                    |namespace MyTestLibrary.Test
+                    |{
+                    |    static class Helper
+                    |    {
+                    |        static int sum2(int i, int j)
+                    |        {
+                    |            return i + j;
+                    |        }
+                    |    }
+                    |}
+                """.trimMargin(),
+            filePath("other", "thing", "Helper.cs") to """
+                    |namespace MyTestLibrary.Other.Thing
+                    |{
+                    |    static class Whatever
+                    |    {
+                    |        // Just here for funzies.
+                    |    }
+                    |}
+                """.trimMargin(),
+        )
+        assertGenerateWanted(
+            inputs = listOf(
+                filePath("test", "rand.temper") to """
+                    |@connected
+                    |export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                    |
+                    |export let inc(i: Int): Int {
+                    |    sum(i, 1)
+                    |}
+                """.trimMargin(),
+                filePath("test", "IgnoreMe.txt") to """
+                    |Hi there!!!
+                """.trimMargin(),
+            ) + connecteds,
+            classes = mapOf(
+                "TestGlobal" to Content(
+                    usings = "",
+                    decls = """
+                    |public static class TestGlobal
+                    |{
+                    |    public static int Sum(int i__0, int j__0, int ? bonus = null)
+                    |    {
+                    |        int return__0;
+                    |        int bonus__0;
+                    |        if (bonus == null)
+                    |        {
+                    |            bonus__0 = 0;
+                    |        }
+                    |        else
+                    |        {
+                    |            bonus__0 = bonus.Value;
+                    |        }
+                    |        return TestConnected.Sum(i__0, j__0, bonus__0);
+                    |    }
+                    |    public static int Inc(int i__1)
+                    |    {
+                    |        return Sum(i__1, 1);
+                    |    }
+                    |}
+                """.trimMargin(),
+                ),
+            ),
+            outputs = connecteds.map { (filePath, content) ->
+                val segments = buildList {
+                    addAll(chooseSubspace(filePath.segments.subList(0, filePath.segments.size - 1)))
+                    add(filePath.segments.last().fullName)
+                }
+                filePath(segments) to content
+            },
+        )
+    }
 }
 
 private fun assertGenerateWanted(
@@ -1519,7 +1612,14 @@ private fun assertGenerateWanted(
     errors: List<String> = listOf(),
     moduleName: String = "test",
     namespaceName: String = moduleName.camelToPascal(),
+    outputs: List<Pair<FilePath, String>> = listOf(),
 ) {
+    // Build a tree-structured representation of outputs for easier nested handling.
+    val outputsFs = MemoryFileSystem()
+    for ((srcPath, content) in outputs) {
+        outputsFs.write(srcPath, content.toByteArray())
+    }
+    // Now build overall output structure.
     val want = object : Structured {
         override fun destructure(structureSink: StructureSink) = structureSink.run {
             obj {
@@ -1535,8 +1635,10 @@ private fun assertGenerateWanted(
                                 }
                                 key("src") {
                                     obj {
+                                        // Primary namespace with somewhat automated content.
                                         key(namespaceName) {
                                             obj {
+                                                // Classes.
                                                 classes.entries.forEach { (className, content) ->
                                                     key("$className.cs") {
                                                         obj {
@@ -1562,6 +1664,7 @@ private fun assertGenerateWanted(
                                                         value("__DO_NOT_CARE__")
                                                     }
                                                 }
+                                                // Global.
                                                 val globalName = "${namespaceName}Global"
                                                 if (globalName !in classes) {
                                                     key("$globalName.cs") {
@@ -1571,8 +1674,22 @@ private fun assertGenerateWanted(
                                                         value("__DO_NOT_CARE__")
                                                     }
                                                 }
+                                                // Extras.
+                                                val dirPath = dirPath(namespaceName)
+                                                when (outputsFs.classify(dirPath)) {
+                                                    FileClassification.Directory ->
+                                                        genStructureKids(outputsFs, dirPath)
+                                                    else -> {}
+                                                }
                                             }
                                         }
+                                        // Explicit outputs outside primary namespace.
+                                        for (kid in outputsFs.directoryListing(dirPath()).result!!) {
+                                            if (kid.segments.first().fullName != namespaceName) {
+                                                genStructure(outputsFs, kid)
+                                            }
+                                        }
+                                        // Always content.
                                         key("Logging.cs") { value("__DO_NOT_CARE__") }
                                         key("MyTestLibrary.csproj") { value("__DO_NOT_CARE__") }
                                         key("MyTestLibraryGlobal.cs") { value("__DO_NOT_CARE__") }
@@ -1599,6 +1716,26 @@ private fun assertGenerateWanted(
         inputs = inputs,
         wantJson = FormattingStructureSink.toJsonString(want),
     )
+}
+
+private fun PropertySink.genStructure(fs: MemoryFileSystem, path: FilePath) {
+    key(path.segments.last().fullName) {
+        obj {
+            when (fs.classify(path)) {
+                FileClassification.File -> key("content") {
+                    value(fs.readBinaryFileContentSync(path).result!!.decodeToString())
+                }
+                FileClassification.Directory -> genStructureKids(fs, path)
+                FileClassification.DoesNotExist -> {}
+            }
+        }
+    }
+}
+
+private fun PropertySink.genStructureKids(fs: MemoryFileSystem, dirPath: FilePath) {
+    for (kid in fs.directoryListing(dirPath).result!!) {
+        genStructure(fs, kid)
+    }
 }
 
 private fun assertGeneratedGlobalClass(

--- a/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
+++ b/be-csharp/src/commonTest/kotlin/lang/temper/be/csharp/CSharpBackendTest.kt
@@ -1518,7 +1518,7 @@ class CSharpBackendTest {
                     |        }
                     |    }
                     |}
-                """.trimMargin(),
+            """.trimMargin(),
             filePath("test", "Helper.cs") to """
                     |namespace MyTestLibrary.Test
                     |{
@@ -1530,7 +1530,7 @@ class CSharpBackendTest {
                     |        }
                     |    }
                     |}
-                """.trimMargin(),
+            """.trimMargin(),
             filePath("other", "thing", "Whatever.cs") to """
                     |namespace MyTestLibrary.Other.Thing
                     |{
@@ -1539,7 +1539,7 @@ class CSharpBackendTest {
                     |        // Just here for funzies.
                     |    }
                     |}
-                """.trimMargin(),
+            """.trimMargin(),
         )
         assertGenerateWanted(
             inputs = listOf(
@@ -1580,7 +1580,7 @@ class CSharpBackendTest {
                     |        return Sum(i__1, 1);
                     |    }
                     |}
-                """.trimMargin(),
+                    """.trimMargin(),
                 ),
             ),
             outputs = connecteds.map { (filePath, content) ->

--- a/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
+++ b/be-java/src/commonMain/kotlin/lang/temper/be/java/JavaBackend.kt
@@ -14,10 +14,12 @@ import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
 import lang.temper.library.LibraryConfigurations
 import lang.temper.log.FilePath
+import lang.temper.log.asFilePath
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
 import lang.temper.log.plus
+import lang.temper.log.resolveFile
 import lang.temper.name.BackendId
 import lang.temper.name.BackendMeta
 import lang.temper.name.FileType
@@ -152,10 +154,15 @@ class JavaBackend private constructor(
             )
             add(result)
         }
+        // Copy raw java files into package dirs.
+        val javaLibConfig = JavaLibraryConfig(libraryConfigurations.currentLibraryConfiguration)
         for (file in rawBackendFiles) {
-            // Just copy raw java files into package dirs.
+            val modulePath = file.key.segments.subList(0, file.key.segments.size - 1).asFilePath()
+            val packageName = javaLibConfigs.packageNameFor(modulePath, javaLibConfig)
+            val packagePath = dirPath(packageName.parts.map { it.outputNameText })
+            val filePath = packagePath.resolveFile(file.key.segments.last())
             MetadataFileSpecification(
-                path = J.SourceDirectory.MainJava.filePath.resolve(file.key),
+                path = J.SourceDirectory.MainJava.filePath.resolve(filePath),
                 mimeType = sourceMimeType,
                 content = file.value,
             ).also { add(it) }

--- a/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
+++ b/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
@@ -2144,15 +2144,14 @@ class JavaBackendTest {
 
     @Test
     fun connected() = assertGeneratedJavaRaw(
-        // TODO More connected. Less other stuff.
         inputs = inputFileMapFromJson(
+            // Test using a submodule.
             """
                 |{
                 |  sub: {
                 |    things.temper: ```
                 |      @connected
                 |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
-                |
                 |      export let inc(i: Int): Int {
                 |          sum(i, 1)
                 |      }
@@ -2212,10 +2211,12 @@ class JavaBackendTest {
             |
             |            ```,
             |      },
+            |## Connected code gets copied into same package dir.
             |      "SubConnected.java": "__DO_NOT_CARE__",
             |      "SubMain.java.map": "__DO_NOT_CARE__",
             |      "SubGlobal.java.map": "__DO_NOT_CARE__",
             |  },
+            |## Other raw files also get copied into package dirs by temper module dir.
             |  "other": {
             |      "thing": {
             |          "Whatever.java": "__DO_NOT_CARE__",

--- a/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
+++ b/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
@@ -2143,6 +2143,93 @@ class JavaBackendTest {
     )
 
     @Test
+    fun connected() = assertGeneratedJavaRaw(
+        // TODO More connected. Less other stuff.
+        inputs = inputFileMapFromJson(
+            """
+                |{
+                |  config.temper.md: ```
+                |    # My test library
+                |    ```,
+                |  sub: {
+                |    things.temper: ```
+                |      @connected
+                |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                |
+                |      export let inc(i: Int): Int {
+                |          sum(i, 1)
+                |      }
+                |      ```,
+                |    SubConnected.java: ```
+                |      package my_test_library.sub;
+                |
+                |      class SubConnected {
+                |          static int sum(int i, int j, int bonus) {
+                |              return i + j + bonus;
+                |          }
+                |      }
+                |      ```,
+                |  },
+                |  other: {
+                |    thing: {
+                |      Whatever.java: ```
+                |        package my_test_library.other.thing;
+                |
+                |        class Whatever {}
+                |        ```,
+                |    },
+                |  },
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |src: { main: { java: { my_test_library: {
+            |  MyTestLibraryGlobal.java: "__DO_NOT_CARE__",
+            |  MyTestLibraryMain.java: "__DO_NOT_CARE__",
+            |  "sub": {
+            |      "SubMain.java": "__DO_NOT_CARE__",
+            |      "SubGlobal.java": {
+            |          "content": ```
+            |            package my_test_library.sub;
+            |            import temper.core.Nullable;
+            |            public final class SubGlobal {
+            |                private SubGlobal() {
+            |                }
+            |                public static int sum(int i__0, int j__0, @Nullable Integer bonus__0) {
+            |                    int return__0;
+            |                    int bonus__1;
+            |                    if (bonus__0 == null) {
+            |                        bonus__1 = 0;
+            |                    } else {
+            |                        bonus__1 = bonus__0;
+            |                    }
+            |                    return SubConnected.sum(i__0, j__0, bonus__1);
+            |                }
+            |                public static int sum(int i__0, int j__0) {
+            |                    return sum(i__0, j__0, null);
+            |                }
+            |                public static int inc(int i__1) {
+            |                    return SubGlobal.sum(i__1, 1);
+            |                }
+            |            }
+            |
+            |            ```,
+            |      },
+            |      "SubConnected.java": "__DO_NOT_CARE__",
+            |      "SubMain.java.map": "__DO_NOT_CARE__",
+            |      "SubGlobal.java.map": "__DO_NOT_CARE__",
+            |  },
+            |  "other": {
+            |      "thing": {
+            |          "Whatever.java": "__DO_NOT_CARE__",
+            |      },
+            |  },
+            |} } } },
+            |pom.xml: "__DO_NOT_CARE__"
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
+
+    @Test
     fun stringIndexOptionComparison() {
         assertGeneratedJava(
             """

--- a/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
+++ b/be-java/src/commonTest/kotlin/lang/temper/be/java/JavaBackendTest.kt
@@ -2148,9 +2148,6 @@ class JavaBackendTest {
         inputs = inputFileMapFromJson(
             """
                 |{
-                |  config.temper.md: ```
-                |    # My test library
-                |    ```,
                 |  sub: {
                 |    things.temper: ```
                 |      @connected

--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsBackend.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsBackend.kt
@@ -221,9 +221,10 @@ class JsBackend private constructor(
             }
         }
         // Connected files.
+        val rootSize = libraryConfigurations.currentLibraryConfiguration.libraryRoot.segments.size
         val connectedFiles = rawBackendFiles.map { file ->
             MetadataFileSpecification(
-                path = FilePath(file.key.segments.subListToEnd(1), isDir = false),
+                path = FilePath(file.key.segments.subListToEnd(rootSize), isDir = false),
                 mimeType = MimeType.javascript,
                 content = file.value,
             )

--- a/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
+++ b/be-js/src/commonMain/kotlin/lang/temper/be/js/JsTranslator.kt
@@ -210,13 +210,16 @@ internal class JsTranslator(
         val prodImports = filterImports(prodModuleParts.topLevels, imports)
         prodModuleParts.explicitImports.addAll(prodImports)
         if (hasConnected) {
+            val relativePath = t.codeLocation.codeLocation.relativePath()
+            // All except top-level connecteds go down a subdir along with temper-built submodules.
+            val dirName = relativePath.segments.lastOrNull()?.fullName?.let { "./$it" } ?: "."
             Js.ImportDeclaration(
                 t.pos,
                 specifiers = Js.ImportNamespaceSpecifier(
                     t.pos,
                     Js.Identifier(t.pos, connectedName, null),
                 ).let { listOf(it) },
-                source = Js.StringLiteral(t.pos, "./_connected.js"),
+                source = Js.StringLiteral(t.pos, "$dirName/_connected.js"),
             ).also { prodModuleParts.explicitImports.add(it) }
         }
 

--- a/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
+++ b/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
@@ -2475,7 +2475,8 @@ class JsBackendTest {
                 |        }
                 |        ```,
                 |      _connected.js: ```
-                |        import "../foo.internal.js"; // where "../" required here
+                |        // Importing with "../" required here. See layout later for more.
+                |        import "../foo.internal.js";
                 |        export const sum = (i, j, bonus) => {
                 |          return i + j + bonus;
                 |        };
@@ -2543,7 +2544,12 @@ class JsBackendTest {
             |
             |            ```
             |        },
+            |## As for cpp, we currently put foo(.internal?).js at the upper level.
             |        "foo.js": "__DO_NOT_CARE__",
+            |## And because we don't export internal modules in package.json, we can't
+            |## do a outer-namespaced import of the internal module, so we currently
+            |## have to pay attention to when we need to "../" import things from this
+            |## subdir. Maybe we can always make "foo/index.js" in the future instead.
             |        "foo": {
             |          "_connected.js": "__DO_NOT_CARE__",
             |          "deeper.js": "__DO_NOT_CARE__",
@@ -2578,7 +2584,7 @@ class JsBackendTest {
             |    }
             |  }
             |}
-        """.trimMargin(),
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )
 }
 

--- a/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
+++ b/be-js/src/commonTest/kotlin/lang/temper/be/js/JsBackendTest.kt
@@ -2454,6 +2454,132 @@ class JsBackendTest {
             |}
         """.trimMargin(),
     )
+
+    @Test
+    fun connected() = assertGeneratedCode(
+        inputs = inputFileMapFromJson(
+            """
+                |{
+                |  src: {
+                |    foo: {
+                |      blah.temper: ```
+                |        let { prod } = import("./deeper");
+                |        export let twice(i: Int): Int {
+                |          prod(i, 2)
+                |        }
+                |
+                |        @connected
+                |        export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                |        export let inc(i: Int): Int {
+                |            sum(i, 1)
+                |        }
+                |        ```,
+                |      _connected.js: ```
+                |        import "../foo.internal.js"; // where "../" required here
+                |        export const sum = (i, j, bonus) => {
+                |          return i + j + bonus;
+                |        };
+                |        ```,
+                |      deeper: {
+                |        things.temper: ```
+                |          export let prod(i: Int, j: Int): Int {
+                |              i * j
+                |          }
+                |          ```
+                |      }
+                |    },
+                |    other: {
+                |      thing: {
+                |        whatever.js: "// Content doesn't matter.",
+                |      },
+                |    },
+                |  }
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |  "js": {
+            |    "my-test-library": {
+            |      "src": {
+            |        "foo.internal.js": {
+            |          "content": ```
+            |            import {
+            |              prod as prod_0
+            |            } from "./foo/deeper.js";
+            |            import * as _connected from "./foo/_connected.js";
+            |            import {
+            |              panic as panic_0
+            |            } from "@temperlang/core";
+            |            /**
+            |             * @param {number} i_0
+            |             * @returns {number}
+            |             */
+            |            export function twice(i_0) {
+            |              return prod_0(i_0, 2);
+            |            };
+            |            /**
+            |             * @param {number} i_1
+            |             * @param {number} j_0
+            |             * @param {number | null} [bonus_0]
+            |             * @returns {number}
+            |             */
+            |            export function sum(i_1, j_0, bonus_0) {
+            |              let bonus_1;
+            |              if (bonus_0 == null) {
+            |                bonus_1 = 0;
+            |              } else {
+            |                bonus_1 = bonus_0;
+            |              }
+            |              return _connected.sum(i_1, j_0, bonus_1);
+            |            };
+            |            /**
+            |             * @param {number} i_2
+            |             * @returns {number}
+            |             */
+            |            export function inc(i_2) {
+            |              return sum(i_2, 1);
+            |            };
+            |
+            |            ```
+            |        },
+            |        "foo.js": "__DO_NOT_CARE__",
+            |        "foo": {
+            |          "_connected.js": "__DO_NOT_CARE__",
+            |          "deeper.js": "__DO_NOT_CARE__",
+            |          "deeper.js.map": "__DO_NOT_CARE__",
+            |          "deeper.internal.js": "__DO_NOT_CARE__",
+            |          "deeper.internal.js.map": "__DO_NOT_CARE__",
+            |        },
+            |        "other": {
+            |          "thing": {
+            |            "whatever.js": "__DO_NOT_CARE__",
+            |          },
+            |        },
+            |        "foo.js.map": "__DO_NOT_CARE__",
+            |        "foo.internal.js.map": "__DO_NOT_CARE__",
+            |      },
+            |      "package.json": {
+            |        jsonContent: {
+            |          "name": "my-test-library",
+            |          "type": "module",
+            |          "exports": {
+            |            // Showing json to emphasize what's exported, which excludes connected.
+            |            "./src/foo/deeper": "./src/foo/deeper.js",
+            |            "./src/foo": "./src/foo.js",
+            |            ".": "./index.js"
+            |          },
+            |          "dependencies": {
+            |            "@temperlang/core": "0.6.0"
+            |          }
+            |        },
+            |      },
+            |      "index.js": "__DO_NOT_CARE__",
+            |    }
+            |  }
+            |}
+        """.trimMargin(),
+    )
 }
 
 private const val OUTPUT_BOILERPLATE = """

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaBackend.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaBackend.kt
@@ -97,10 +97,10 @@ class LuaBackend private constructor(
                 // Special _connected.lua file gets inlined.
                 file.key.last().fullName == "_connected.lua" && continue@rawBackendFiles
                 // Others get copied.
-                // TODO Make sure things get into good places.
+                val rootSize = libraryConfigurations.currentLibraryConfiguration.libraryRoot.segments.size
                 MetadataFileSpecification(
                     // Skip the library name part.
-                    path = file.key.segments.subListToEnd(1).asFilePath(),
+                    path = file.key.segments.subListToEnd(rootSize).asFilePath(),
                     mimeType = MimeType.luaSource,
                     content = file.value,
                 ).also { add(it) }

--- a/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
+++ b/be-lua/src/commonMain/kotlin/lang/temper/be/lua/LuaTranslator.kt
@@ -2515,11 +2515,11 @@ private class ModuleParts(
         val withLocals = luaChunk(
             pos,
             buildList {
-                addAll(imports)
-                addAll(preDecls)
                 if (connectedSource != null) {
                     add(Lua.Connected(pos, connectedSource))
                 }
+                addAll(imports)
+                addAll(preDecls)
                 addAll(globalFuncs)
                 addAll(topLevels)
                 addAll(exports)

--- a/be-lua/src/commonTest/kotlin/lang/temper/be/lua/LuaBackendTest.kt
+++ b/be-lua/src/commonTest/kotlin/lang/temper/be/lua/LuaBackendTest.kt
@@ -2,6 +2,8 @@ package lang.temper.be.lua
 
 import lang.temper.be.Backend
 import lang.temper.be.assertGeneratedCode
+import lang.temper.common.stripDoubleHashCommentLinesToPutCommentsInlineBelow
+import lang.temper.log.FilePath
 import lang.temper.log.filePath
 import kotlin.test.Test
 
@@ -364,6 +366,96 @@ class LuaBackendTest {
             |
         """.trimMargin(),
     )
+
+    @Test
+    fun connected() = assertGeneratedLua(
+        inputs = listOf(
+            filePath("something", "something.temper") to """
+                |let { prod } = import("./deeper");
+                |export let twice(i: Int): Int {
+                |  prod(i, 2)
+                |}
+                |
+                |@connected
+                |export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                |export let inc(i: Int): Int {
+                |    sum(i, 1)
+                |}
+            """.trimMargin(),
+            filePath("something", "deeper", "more-fun.temper") to """
+                |export let prod(i: Int, j: Int): Int {
+                |    i * j
+                |}
+            """.trimMargin(),
+            filePath("something", "_connected.lua") to """
+                |local _connected = {}
+                |do
+                |  -- Show example require in connected code, even if we don't use it here.
+                |  local s = require("my-test-library.something._support")
+                |  function _connected.sum(i, j, bonus)
+                |    return i + j + bonus
+                |  end
+                |end
+                |
+            """.trimMargin(),
+            filePath("something", "_support.lua") to """
+                |-- Content doesn't matter.
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |    "lua": {
+            |        "my-test-library": {
+            |            "something.lua": {
+            |                "content": ```
+            |                  local temper = require('temper-core');
+            |                  local prod, twice, sum, inc, exports;
+            |                  prod = temper.import('my-test-library/something/deeper', 'prod');
+            |## Here's where the inlining happens. We need to specify to define `_connected` as only top-level.
+            |                  local _connected = {}
+            |                  do
+            |                    -- Show example require in connected code, even if we don't use it here.
+            |                    local s = require("my-test-library.something._support")
+            |                    function _connected.sum(i, j, bonus)
+            |                      return i + j + bonus
+            |                    end
+            |                  end
+            |                  twice = function(i__0)
+            |                    return prod(i__0, 2);
+            |                  end;
+            |                  sum = function(i__1, j__0, bonus__0)
+            |                    local bonus__1;
+            |                    if temper.is_null(bonus__0) then
+            |                      bonus__1 = 0;
+            |                    else
+            |                      bonus__1 = bonus__0;
+            |                    end
+            |                    return _connected.sum(i__1, j__0, bonus__1);
+            |                  end;
+            |                  inc = function(i__2)
+            |                    return sum(i__2, 1);
+            |                  end;
+            |                  exports = {};
+            |                  exports.twice = twice;
+            |                  exports.sum = sum;
+            |                  exports.inc = inc;
+            |                  return exports;
+            |
+            |                  ```
+            |            },
+            |            "something": {
+            |                "deeper.lua": "__DO_NOT_CARE__",
+            |                "deeper.lua.map": "__DO_NOT_CARE__",
+            |                "_support.lua": "__DO_NOT_CARE__",
+            |            },
+            |            "init.lua": "__DO_NOT_CARE__",
+            |            "something.lua.map": "__DO_NOT_CARE__",
+            |            "my-test-library-dev-1.rockspec": "__DO_NOT_CARE__",
+            |        }
+            |    }
+            |}
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
 }
 
 private fun assertGenerated(
@@ -376,11 +468,8 @@ private fun assertGenerated(
         |$lua
         |```
     """.trimMargin()
-    assertGeneratedCode(
-        backendConfig = Backend.Config.production,
-        factory = LuaBackend.Lua51,
+    assertGeneratedLua(
         inputs = listOf(filePath("something", "something.temper") to temper),
-        moduleResultNeeded = false,
         want = """
             |{
             |    "lua": {
@@ -395,5 +484,17 @@ private fun assertGenerated(
             |    }
             |}
         """.trimMargin(),
+    )
+}
+
+private fun assertGeneratedLua(
+    inputs: List<Pair<FilePath, String>>,
+    want: String,
+) {
+    assertGeneratedCode(
+        backendConfig = Backend.Config.production,
+        factory = LuaBackend.Lua51,
+        inputs = inputs,
+        want = want,
     )
 }

--- a/be-lua/src/commonTest/kotlin/lang/temper/be/lua/LuaBackendTest.kt
+++ b/be-lua/src/commonTest/kotlin/lang/temper/be/lua/LuaBackendTest.kt
@@ -368,6 +368,93 @@ class LuaBackendTest {
     )
 
     @Test
+    fun testing() = assertGeneratedLua(
+        inputs = listOf(
+            filePath("something", "something.temper") to """
+                |export let inc(i: Int): Int {
+                |  sum(i, 1)
+                |}
+                |test("sum") {
+                |  assert(sum(1, 2) == 3);
+                |}
+                |let sum(i: Int, j: Int): Int {
+                |  console.log("hi");
+                |  i + j
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |    "lua": {
+            |        "my-test-library": {
+            |            "something.lua": {
+            |                "content": ```
+            |## Use absolute imports consistently in lua to help proper caching.
+            |                  local imports = require('my-test-library/something-internal');
+            |                  return {inc = imports.inc};
+            |
+            |                  ```
+            |            },
+            |            "something-internal.lua": {
+            |                "content": ```
+            |                  local temper = require('temper-core');
+            |                  local console_0, sum__0, inc, exports;
+            |                  console_0 = 0.0;
+            |                  sum__0 = function(i__0, j__0)
+            |                    temper.log('hi');
+            |                    return temper.int32_add(i__0, j__0);
+            |                  end;
+            |                  inc = function(i__1)
+            |                    return sum__0(i__1, 1);
+            |                  end;
+            |                  exports = {};
+            |                  exports.inc = inc;
+            |                  exports.sum__0 = sum__0;
+            |                  return exports;
+            |
+            |                  ```
+            |            },
+            |            "tests": {
+            |                "something-test.lua": {
+            |                    content: ```
+            |                      local temper = require('temper-core');
+            |                      local sum__0, local_4, local_5, exports;
+            |                      sum__0 = temper.import('my-test-library/something-internal', 'sum__0');
+            |                      local_4 = (unpack or table.unpack);
+            |                      local_5 = require('luaunit');
+            |                      local_5.FAILURE_PREFIX = temper.test_failure_prefix;
+            |                      Test_ = {};
+            |                      Test_.test_sum__0 = function()
+            |                        temper.test('sum', function(test_1)
+            |                          local actual_2, t_3, fn__0;
+            |                          actual_2 = sum__0(1, 2);
+            |                          t_3 = (actual_2 == 3);
+            |                          fn__0 = function()
+            |                            return temper.concat('expected sum(1, 2) == (', temper.int32_tostring(3), ') not (', temper.int32_tostring(actual_2), ')');
+            |                          end;
+            |                          temper.test_assert(test_1, t_3, fn__0);
+            |                          return nil;
+            |                        end);
+            |                      end;
+            |                      exports = {};
+            |                      local_5.LuaUnit.run(local_4({'--pattern', '^Test_%.', local_4(arg)}));
+            |                      return exports;
+            |
+            |                      ```
+            |                },
+            |                "something-test.lua.map": "__DO_NOT_CARE__",
+            |            },
+            |            "init.lua": "__DO_NOT_CARE__",
+            |            "something.lua.map": "__DO_NOT_CARE__",
+            |            "something-internal.lua.map": "__DO_NOT_CARE__",
+            |            "my-test-library-dev-1.rockspec": "__DO_NOT_CARE__",
+            |        }
+            |    }
+            |}
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
+
+    @Test
     fun connected() = assertGeneratedLua(
         inputs = listOf(
             filePath("something", "something.temper") to """
@@ -388,16 +475,18 @@ class LuaBackendTest {
                 |}
             """.trimMargin(),
             filePath("something", "_connected.lua") to """
+                |## Only `_connected` should be defined at top level here.
                 |local _connected = {}
                 |do
-                |  -- Show example require in connected code, even if we don't use it here.
+                |## Show example require in connected code, even if we don't use it here.
+                |## And note that absolute rather than relative imports work here.
                 |  local s = require("my-test-library.something._support")
                 |  function _connected.sum(i, j, bonus)
                 |    return i + j + bonus
                 |  end
                 |end
                 |
-            """.trimMargin(),
+            """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
             filePath("something", "_support.lua") to """
                 |-- Content doesn't matter.
             """.trimMargin(),
@@ -410,16 +499,16 @@ class LuaBackendTest {
             |                "content": ```
             |                  local temper = require('temper-core');
             |                  local prod, twice, sum, inc, exports;
-            |                  prod = temper.import('my-test-library/something/deeper', 'prod');
-            |## Here's where the inlining happens. We need to specify to define `_connected` as only top-level.
+            |## Inline connected code *after* locals are defined to allow access from connected code.
             |                  local _connected = {}
             |                  do
-            |                    -- Show example require in connected code, even if we don't use it here.
             |                    local s = require("my-test-library.something._support")
             |                    function _connected.sum(i, j, bonus)
             |                      return i + j + bonus
             |                    end
             |                  end
+            |## Then other translated code follows, noting that things aren't defined during *init* above.
+            |                  prod = temper.import('my-test-library/something/deeper', 'prod');
             |                  twice = function(i__0)
             |                    return prod(i__0, 2);
             |                  end;

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
@@ -19,6 +19,7 @@ import lang.temper.common.MimeType
 import lang.temper.common.console
 import lang.temper.common.jsonEscaper
 import lang.temper.common.partitionNotNull
+import lang.temper.common.subListToEnd
 import lang.temper.common.toStringViaBuilder
 import lang.temper.fs.ResourceDescriptor
 import lang.temper.fs.declareResources
@@ -36,6 +37,7 @@ import lang.temper.library.versionOrDefault
 import lang.temper.log.FilePath
 import lang.temper.log.FilePathSegment
 import lang.temper.log.Position
+import lang.temper.log.asFilePath
 import lang.temper.log.dirPath
 import lang.temper.log.filePath
 import lang.temper.log.last
@@ -306,10 +308,14 @@ class PyBackend private constructor(
         rawBackendFiles@ for (file in rawBackendFiles) {
             // Special __connected__.py file gets inlined.
             file.key.last().fullName == "__connected__.py" && continue@rawBackendFiles
-            // Others get copied.
-            // TODO Make sure things get into good places.
+            // Others get copied, stripping the root path then prefixing the library name.
+            val rootSize = libraryConfigurations.currentLibraryConfiguration.libraryRoot.segments.size
+            val path = buildList {
+                add(FilePathSegment(pyLibraryName.text))
+                addAll(file.key.segments.subListToEnd(rootSize))
+            }.asFilePath()
             MetadataFileSpecification(
-                path = file.key,
+                path = path,
                 mimeType = mimeType,
                 content = file.value,
             ).also { outputFileSpecifications.add(it) }
@@ -441,7 +447,7 @@ class PyBackend private constructor(
                                 val relImportPath = listOf("", program.outputPath.segments.last().baseName)
                                 Py.ImportWildcardFrom(
                                     unknownPos,
-                                    Py.ImportDotted(unknownPos, PyDottedIdentifier.dotted(relImportPath)),
+                                    Py.ImportDotted(unknownPos, dotted(relImportPath)),
                                 )
                             } else {
                                 // Import each, but make them ugly. This is for init side effects, not convenience.

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyBackend.kt
@@ -314,11 +314,13 @@ class PyBackend private constructor(
                 add(FilePathSegment(pyLibraryName.text))
                 addAll(file.key.segments.subListToEnd(rootSize))
             }.asFilePath()
-            MetadataFileSpecification(
-                path = path,
-                mimeType = mimeType,
-                content = file.value,
-            ).also { outputFileSpecifications.add(it) }
+            topModule.setOutputFile(
+                MetadataFileSpecification(
+                    path = path,
+                    mimeType = mimeType,
+                    content = file.value,
+                ),
+            )
         }
         if (config.makeMetaDataFile || anyTests) {
             val dependencies = buildList {
@@ -335,7 +337,7 @@ class PyBackend private constructor(
         }
         topModule.mapNotNullTo(outputFileSpecifications) { mod ->
             if (mod.moduleId != null) {
-                mod.write().toTreeFile()
+                mod.toOutputFile()
             } else {
                 null
             }

--- a/be-py/src/commonMain/kotlin/lang/temper/be/py/PyModule.kt
+++ b/be-py/src/commonMain/kotlin/lang/temper/be/py/PyModule.kt
@@ -10,11 +10,16 @@ import lang.temper.name.OutName
 import lang.temper.value.DependencyCategory
 
 /**
- * A layout data structure that lets us put AST nodes into python modules and figures out the __init__.py for us.
+ * A layout data structure that lets us put AST nodes or explicit file content
+ * into python modules and figures out the __init__.py for us.
  */
 class PyModule(var moduleId: PyDottedIdentifier?) : Iterable<PyModule> {
+    // Only one of program or outputFile is set at most.
     var program: Py.Program? = null
         private set
+    var outputFile: Backend.OutputFileSpecification? = null
+        private set
+
     private val modules: MutableMap<OutName, PyModule> = mutableMapOf()
     val exports: MutableSet<OutName> = mutableSetOf()
     val imports: MutableSet<OutName> = mutableSetOf()
@@ -25,14 +30,26 @@ class PyModule(var moduleId: PyDottedIdentifier?) : Iterable<PyModule> {
         return modules.getOrPut(name) { PyModule(moduleId.dot(name)) }
     }
 
-    /** Intended for a top level module, this sets a program based on its path. */
+    /** Intending `this` for a top level module, set a program based on its path. */
     fun setProgram(program: Py.Program): PyModule {
-        val path = program.outputPath
+        val node = expand(program.outputPath)
+        node.program = program
+        return node
+    }
+
+    /** Intending `this` for a top level module, set a program based on its path. */
+    fun setOutputFile(outputFile: Backend.OutputFileSpecification): PyModule {
+        val node = expand(outputFile.path)
+        node.outputFile = outputFile
+        return node
+    }
+
+    /** Expand out and store nodes for the path, with no associated program. */
+    private fun expand(path: FilePath): PyModule {
         var node = this
         for (seg in path.segments) {
             node = node[safeModuleName(seg.baseName)]
         }
-        node.program = program
         return node
     }
 
@@ -87,8 +104,11 @@ class PyModule(var moduleId: PyDottedIdentifier?) : Iterable<PyModule> {
      *   OutDir(dir/project/bar)
      *   OutRegularFile(dir/project/bar/__init__.py), Py.Program('def bar(): ...')
      * ```
+     *
+     * Or if this module is already associated with an explicit
+     * [Backend.OutputFileSpecification], just provide that instead.
      */
-    fun write(): PyFile {
+    fun toOutputFile(): Backend.OutputFileSpecification {
         val modulePath = moduleId?.absModulePath() ?: FilePath.emptyPath
         val dir = modulePath.dirName()
         val lastPart = modulePath.segments.last()
@@ -100,7 +120,7 @@ class PyModule(var moduleId: PyDottedIdentifier?) : Iterable<PyModule> {
             // Can be represented as a simple name.py module.
             dir + lastPart.withExtension(PyBackend.fileExtension)
         }
-        return PyFile(program, moduleId, file)
+        return outputFile ?: PyFile(program, moduleId, file).toTreeFile()
     }
 
     override fun iterator(): Iterator<PyModule> = dequeIterator { deque ->

--- a/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
+++ b/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
@@ -699,6 +699,96 @@ class PyBackendTest {
         """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )
 
+    @Test
+    fun connected() = assertGeneratedCode(
+        inputs = inputFileMapFromJson(
+            """
+            |{
+            |  foo: {
+            |    foo.temper: ```
+            |      // let { prod } = import("./deeper");
+            |      // export let twice(i: Int): Int {
+            |      //   prod(i, 2)
+            |      // }
+            |
+            |      @connected
+            |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+            |      export let inc(i: Int): Int {
+            |          sum(i, 1)
+            |      }
+            |      ```,
+            |    __connected__.py: ```
+            |      class _connected:
+            |          from ._support import Support
+            |
+            |          def sum(i: int, j: int, bonus: int) -> int:
+            |              return i + j + bonus
+            |
+            |      ```,
+            |    _support.py: ```
+            |      class Support:
+            |          pass
+            |      ```,
+            |  },
+            |}
+            """.trimMargin(),
+//            |    deeper: {
+//            |      things.temper: ```
+//            |        export let prod(i: Int, j: Int): Int {
+//            |            i * j
+//            |        }
+//            |        ```,
+//            |    },
+        ),
+        want = """
+            |{
+            |  py: {
+            |    my-test-library: {
+            |      my_test_library: {
+            |        foo: {
+            |          __init__.py: {
+            |            content:
+            |              ```
+            |              class _connected:
+            |                  from ._support import Support
+            |
+            |                  def sum(i: int, j: int, bonus: int) -> int:
+            |                      return i + j + bonus
+            |              from my_test_library.foo.deeper import prod as prod_3
+            |              from builtins import int as int1
+            |              from typing import Union as Union3
+            |              from temper_core import bubble as bubble2
+            |              bubble_17 = bubble2
+            |              def twice(i_4: 'int1', /) -> 'int1':
+            |                  return prod_3(i_4, 2)
+            |              def sum(i_6: 'int1', j_7: 'int1', bonus_12: 'Union3[int1, None]' = None, /) -> 'int1':
+            |                  _bonus_12: 'Union3[int1, None]' = bonus_12
+            |                  return_1: 'int1'
+            |                  bonus_8: 'int1'
+            |                  if _bonus_12 is None:
+            |                      bonus_8 = 0
+            |                  else:
+            |                      bonus_8 = _bonus_12
+            |                  return _connected.sum(i_6, j_7, bonus_8)
+            |              def inc(i_10: 'int1', /) -> 'int1':
+            |                  return sum(i_10, 1)
+            |
+            |              ```,
+            |          },
+            |          _support.py: "__DO_NOT_CARE__",
+            |          deeper.py: "__DO_NOT_CARE__",
+            |          deeper.py.map: "__DO_NOT_CARE__",
+            |          __init__.py.map: "__DO_NOT_CARE__",
+            |        },
+            |        "__init__.py": "__DO_NOT_CARE__",
+            |        "__init__.py.map": "__DO_NOT_CARE__"
+            |      },
+            |    },
+            |  }
+            |}
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
+    )
+
     private fun assertGeneratedCode(
         inputs: List<Pair<FilePath, String>>,
         want: String,

--- a/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
+++ b/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
@@ -706,11 +706,6 @@ class PyBackendTest {
             |{
             |  foo: {
             |    foo.temper: ```
-            |      // let { prod } = import("./deeper");
-            |      // export let twice(i: Int): Int {
-            |      //   prod(i, 2)
-            |      // }
-            |
             |      @connected
             |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
             |      export let inc(i: Int): Int {
@@ -725,20 +720,15 @@ class PyBackendTest {
             |              return i + j + bonus
             |
             |      ```,
+            |## Include this bonus file *without* an explicit temper module at the
+            |## same level to prove we still get a dir for the translated module.
             |    _support.py: ```
             |      class Support:
             |          pass
             |      ```,
             |  },
             |}
-            """.trimMargin(),
-//            |    deeper: {
-//            |      things.temper: ```
-//            |        export let prod(i: Int, j: Int): Int {
-//            |            i * j
-//            |        }
-//            |        ```,
-//            |    },
+            """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
         ),
         want = """
             |{
@@ -754,30 +744,25 @@ class PyBackendTest {
             |
             |                  def sum(i: int, j: int, bonus: int) -> int:
             |                      return i + j + bonus
-            |              from my_test_library.foo.deeper import prod as prod_3
             |              from builtins import int as int1
-            |              from typing import Union as Union3
-            |              from temper_core import bubble as bubble2
-            |              bubble_17 = bubble2
-            |              def twice(i_4: 'int1', /) -> 'int1':
-            |                  return prod_3(i_4, 2)
-            |              def sum(i_6: 'int1', j_7: 'int1', bonus_12: 'Union3[int1, None]' = None, /) -> 'int1':
-            |                  _bonus_12: 'Union3[int1, None]' = bonus_12
-            |                  return_1: 'int1'
-            |                  bonus_8: 'int1'
-            |                  if _bonus_12 is None:
-            |                      bonus_8 = 0
+            |              from typing import Union as Union2
+            |              from temper_core import bubble as bubble0
+            |              bubble_12 = bubble0
+            |              def sum(i_2: 'int1', j_3: 'int1', bonus_8: 'Union2[int1, None]' = None, /) -> 'int1':
+            |                  _bonus_8: 'Union2[int1, None]' = bonus_8
+            |                  return_0: 'int1'
+            |                  bonus_4: 'int1'
+            |                  if _bonus_8 is None:
+            |                      bonus_4 = 0
             |                  else:
-            |                      bonus_8 = _bonus_12
-            |                  return _connected.sum(i_6, j_7, bonus_8)
-            |              def inc(i_10: 'int1', /) -> 'int1':
-            |                  return sum(i_10, 1)
+            |                      bonus_4 = _bonus_8
+            |                  return _connected.sum(i_2, j_3, bonus_4)
+            |              def inc(i_6: 'int1', /) -> 'int1':
+            |                  return sum(i_6, 1)
             |
             |              ```,
             |          },
             |          _support.py: "__DO_NOT_CARE__",
-            |          deeper.py: "__DO_NOT_CARE__",
-            |          deeper.py.map: "__DO_NOT_CARE__",
             |          __init__.py.map: "__DO_NOT_CARE__",
             |        },
             |        "__init__.py": "__DO_NOT_CARE__",

--- a/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
+++ b/be-py/src/commonTest/kotlin/lang/temper/be/py/PyBackendTest.kt
@@ -704,6 +704,7 @@ class PyBackendTest {
         inputs = inputFileMapFromJson(
             """
             |{
+            |## Test using a submodule.
             |  foo: {
             |    foo.temper: ```
             |      @connected
@@ -713,6 +714,7 @@ class PyBackendTest {
             |      }
             |      ```,
             |    __connected__.py: ```
+            |## All connected code goes into a single `_connected` namespace, using a class here.
             |      class _connected:
             |          from ._support import Support
             |
@@ -739,11 +741,13 @@ class PyBackendTest {
             |          __init__.py: {
             |            content:
             |              ```
+            |## Here's the connected code inlined into the primary module *before* imports.
             |              class _connected:
             |                  from ._support import Support
             |
             |                  def sum(i: int, j: int, bonus: int) -> int:
             |                      return i + j + bonus
+            |## Translated code starts here.
             |              from builtins import int as int1
             |              from typing import Union as Union2
             |              from temper_core import bubble as bubble0
@@ -756,12 +760,14 @@ class PyBackendTest {
             |                      bonus_4 = 0
             |                  else:
             |                      bonus_4 = _bonus_8
+            |## Here's the connected call.
             |                  return _connected.sum(i_2, j_3, bonus_4)
             |              def inc(i_6: 'int1', /) -> 'int1':
             |                  return sum(i_6, 1)
             |
             |              ```,
             |          },
+            |## And here's the support file next to the primary module.
             |          _support.py: "__DO_NOT_CARE__",
             |          __init__.py.map: "__DO_NOT_CARE__",
             |        },

--- a/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
+++ b/be-rust/src/commonMain/kotlin/lang/temper/be/rust/RustBackend.kt
@@ -130,7 +130,8 @@ class RustBackend(setup: BackendSetup<RustBackend>) : Backend<RustBackend>(Facto
             // Copy connected code.
             for (file in rawBackendFiles) {
                 // Put rust connected modules into a subdir, under "src/" but skipping library name.
-                val connectedDir = file.key.dirName().resolveDir("_connected").segments.subListToEnd(1)
+                val rootSize = libraryConfiguration.libraryRoot.segments.size
+                val connectedDir = file.key.dirName().resolveDir("_connected").segments.subListToEnd(rootSize)
                 val fileName = when (val fileName = file.key.last().fullName) {
                     "_connected.rs" -> "mod.rs"
                     else -> fileName

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -3,6 +3,7 @@ package lang.temper.be.rust
 import lang.temper.be.Backend
 import lang.temper.be.assertGeneratedCode
 import lang.temper.be.inputFileMapFromJson
+import lang.temper.common.stripDoubleHashCommentLinesToPutCommentsInlineBelow
 import lang.temper.log.FilePath
 import lang.temper.log.filePath
 import lang.temper.name.DashedIdentifier
@@ -191,30 +192,29 @@ class RustBackendTest {
         inputs = inputFileMapFromJson(
             """
                 |{
+                |## Test using a submodule.
                 |  sub: {
                 |    things.temper: ```
                 |      @connected
                 |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
-                |
                 |      export let inc(i: Int): Int {
                 |          sum(i, 1)
                 |      }
                 |      ```,
                 |    _connected.rs: ```
+                |## This submodule declaration in connected code is why we make a subdir later.
+                |      mod whatever;
                 |      pub(crate) fn sum(i: i32, j: i32, bonus: i32) -> i32 {
                 |          i + j + bonus
                 |      }
                 |      ```,
-                |  },
-                |  other: {
-                |    thing: {
-                |      whatever.rs: ```
-                |        // Content doesn't matter.
-                |        ```,
-                |    },
+                |## Include a bonus rust file to show where it ends up relative to connected code.
+                |    whatever.rs: ```
+                |      // Content doesn't matter.
+                |      ```,
                 |  },
                 |}
-            """.trimMargin(),
+            """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
         ),
         want = """
             |{
@@ -255,6 +255,14 @@ class RustBackendTest {
             |
             |              ```
             |          },
+            |          _connected: {
+            |## Raw rust code goes into this subdir so other raw files are below it.
+            |## The original "_connected.rs" gets renamed to "mod.rs", which leaves it
+            |## effectively still just named `_connected`, and "whatever.rs" is now
+            |## `_connected::whatever` relative to anything above.
+            |            mod.rs: "__DO_NOT_CARE__",
+            |            whatever.rs: "__DO_NOT_CARE__",
+            |          },
             |          mod.rs.map: "__DO_NOT_CARE__",
             |        },
             |        $SUPPORT_FILES_DO_NOT_CARE
@@ -262,7 +270,7 @@ class RustBackendTest {
             |    }
             |  }
             |}
-        """.trimMargin(),
+        """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )
 
     @Test

--- a/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
+++ b/be-rust/src/commonTest/kotlin/lang/temper/be/rust/RustBackendTest.kt
@@ -187,6 +187,85 @@ class RustBackendTest {
     )
 
     @Test
+    fun connected() = assertGeneratedFileTree(
+        inputs = inputFileMapFromJson(
+            """
+                |{
+                |  sub: {
+                |    things.temper: ```
+                |      @connected
+                |      export let sum(i: Int, j: Int, bonus: Int = 0): Int;
+                |
+                |      export let inc(i: Int): Int {
+                |          sum(i, 1)
+                |      }
+                |      ```,
+                |    _connected.rs: ```
+                |      pub(crate) fn sum(i: i32, j: i32, bonus: i32) -> i32 {
+                |          i + j + bonus
+                |      }
+                |      ```,
+                |  },
+                |  other: {
+                |    thing: {
+                |      whatever.rs: ```
+                |        // Content doesn't matter.
+                |        ```,
+                |    },
+                |  },
+                |}
+            """.trimMargin(),
+        ),
+        want = """
+            |{
+            |  rust: {
+            |    my-test-library: {
+            |      Cargo.toml: "__DO_NOT_CARE__",
+            |      src: {
+            |        lib.rs: "__DO_NOT_CARE__",
+            |        lib.rs.map: "__DO_NOT_CARE__",
+            |        main.rs: "__DO_NOT_CARE__",
+            |        sub: {
+            |          mod.rs: {
+            |            content: ```
+            |              #![allow(warnings)]
+            |              #![allow(dependency_on_unit_never_type_fallback)]
+            |              mod _connected;
+            |              use temper_core::AnyValueTrait;
+            |              use temper_core::AsAnyValue;
+            |              use temper_core::Pair;
+            |              pub (crate) fn init() -> temper_core::Result<()> {
+            |                  static INIT_ONCE: std::sync::OnceLock<temper_core::Result<()>> = std::sync::OnceLock::new();
+            |                  INIT_ONCE.get_or_init(| |{
+            |                          Ok(())
+            |                  }).clone()
+            |              }
+            |              pub fn sum(i__0: i32, j__0: i32, bonus__0: Option<i32>) -> i32 {
+            |                  let bonus__1: i32;
+            |                  if bonus__0.is_none() {
+            |                      bonus__1 = 0;
+            |                  } else {
+            |                      bonus__1 = bonus__0.unwrap();
+            |                  }
+            |                  _connected::sum(i__0, j__0, bonus__1)
+            |              }
+            |              pub fn inc(i__1: i32) -> i32 {
+            |                  return sum(i__1, 1, None);
+            |              }
+            |
+            |              ```
+            |          },
+            |          mod.rs.map: "__DO_NOT_CARE__",
+            |        },
+            |        $SUPPORT_FILES_DO_NOT_CARE
+            |      }
+            |    }
+            |  }
+            |}
+        """.trimMargin(),
+    )
+
+    @Test
     fun async() {
         assertGenerateWanted(
             temper = """

--- a/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
+++ b/be-test-helpers/src/commonMain/kotlin/lang/temper/be/GeneratedCodeHelper.kt
@@ -17,7 +17,9 @@ import lang.temper.frontend.StagingFlags
 import lang.temper.frontend.staging.ModuleAdvancer
 import lang.temper.frontend.staging.ModuleConfig
 import lang.temper.frontend.staging.partitionSourceFilesIntoModules
+import lang.temper.fs.FileClassification
 import lang.temper.fs.FileFilterRules
+import lang.temper.fs.FileSystem
 import lang.temper.fs.FilteringFileSystemSnapshot
 import lang.temper.fs.MemoryFileSystem
 import lang.temper.fs.NullSystemAccess
@@ -187,6 +189,10 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
             } else {
                 NullSystemAccess(outputRoot.path.resolve(backendLib), cancelGroup)
             }
+            val extensions = factory.backendMeta.fileExtensionMap.values.toSet()
+            val rawBackendFiles = sourceTree.gatherFilesSync { filePath ->
+                filePath.lastOrNull()?.extension?.let { it in extensions } == true
+            }
             this[config] = factory.make(
                 BackendSetup(
                     config.libraryName,
@@ -197,6 +203,7 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
                     logSink,
                     NullDependencyResolver,
                     backendConfig,
+                    rawBackendFiles = rawBackendFiles,
                 ),
             )
         }
@@ -215,4 +222,25 @@ fun <BACKEND : Backend<BACKEND>> generateCode(
         }
         throw e
     }
+}
+
+/**
+ * Map file paths to the textual content of files. Only [keep] files that can be
+ * decoded as UTF-8.
+ */
+fun FileSystem.gatherFilesSync(keep: (FilePath) -> Boolean): Map<FilePath, String> = buildMap {
+    fun addFiles(path: FilePath) {
+        when (classify(path)) {
+            FileClassification.File -> if (keep(path)) {
+                put(path, readBinaryFileContentSync(path).result!!.decodeToString())
+            }
+            FileClassification.Directory -> {
+                for (kid in directoryListing(path).result!!) {
+                    addFiles(kid)
+                }
+            }
+            FileClassification.DoesNotExist -> {}
+        }
+    }
+    addFiles(dirPath())
 }

--- a/functional-test-suite/src/commonMain/resources/functions/connected/_connected.lua
+++ b/functional-test-suite/src/commonMain/resources/functions/connected/_connected.lua
@@ -1,4 +1,4 @@
-local _connected = {};
+local _connected = {}
 
 do
   local s = require("work._support")


### PR DESCRIPTION
- Work toward #456
- Fix some issues, especially paths relative to the library root
- Err on the side of avoiding major changes to backends in this pr
  - But some things demonstrated here might suggest possible further changes in the future
- Some changes:
  - Slightly move connected code injection point in be-lua
  - Count raw files for expanding `foo.py` to `foo/__init.__py` in be-py