### PR TITLE
Check connected limits as they stand today

### DIFF
--- a/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
+++ b/be/src/commonTest/kotlin/lang/temper/be/tmpl/TmpLBackendTest.kt
@@ -2270,7 +2270,13 @@ class TmpLBackendTest {
             |    },
             |    "defines.tmpl.map": "__DO_NOT_CARE__",
             |    "uses.tmpl.map": "__DO_NOT_CARE__",
-            |  }
+            |  },
+            |  errors: [
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |  ]
             |}
         """.trimMargin(),
         supportNetwork = defaultTestSupportNetwork.copy(
@@ -2316,7 +2322,13 @@ class TmpLBackendTest {
             |    },
             |    "defines.tmpl.map": "__DO_NOT_CARE__",
             |    "uses.tmpl.map": "__DO_NOT_CARE__",
-            |  }
+            |  },
+            |  errors: [
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |  ]
             |}
         """.trimMargin(),
         supportNetwork = defaultTestSupportNetwork.copy(
@@ -2363,7 +2375,13 @@ class TmpLBackendTest {
             |    },
             |    "defines.tmpl.map": "__DO_NOT_CARE__",
             |    "uses.tmpl.map": "__DO_NOT_CARE__",
-            |  }
+            |  },
+            |  errors: [
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |  ]
             |}
         """.trimMargin(),
         supportNetwork = defaultTestSupportNetwork.copy(
@@ -2434,6 +2452,13 @@ class TmpLBackendTest {
             |    },
             |    foo.tmpl.map: "__DO_NOT_CARE__",
             |  },
+            |  errors: [
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |  ]
             |}
         """.trimMargin(),
     )
@@ -3624,7 +3649,12 @@ class TmpLBackendTest {
             |        ```
             |    },
             |    "foo.tmpl.map": "__DO_NOT_CARE__",
-            |  }
+            |  },
+            |  errors: [
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |    "At this time, users can connect only top-level functions!",
+            |  ]
             |}
         """.trimMargin().stripDoubleHashCommentLinesToPutCommentsInlineBelow(),
     )

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
@@ -38,6 +38,7 @@ import lang.temper.interp.EmptyEnvironment
 import lang.temper.interp.immutableEnvironment
 import lang.temper.interp.importExport.Importer
 import lang.temper.interp.importExport.STANDARD_LIBRARY_NAME
+import lang.temper.interp.importExport.isEffectivelyStd
 import lang.temper.lexer.Genre
 import lang.temper.lexer.TokenSource
 import lang.temper.log.CodeLocation
@@ -80,6 +81,7 @@ import lang.temper.value.StayLeaf
 import lang.temper.value.TBoolean
 import lang.temper.value.Tree
 import lang.temper.value.Value
+import lang.temper.value.isCore
 import lang.temper.value.toPseudoCode
 import kotlin.math.max
 
@@ -777,24 +779,6 @@ class Module(
         }
 
     private var _dependencyCategory = DependencyCategory.Production
-}
-
-fun ModuleLocation.isEffectivelyStd(sharedLocationContext: SharedLocationContext?): Boolean {
-    if (this is ModuleName) {
-        if (this.isPreface) { return false }
-        val libraryName = sharedLocationContext?.get(this, LibraryNameLocationKey)
-        if (libraryName == DashedIdentifier.temperStandardLibraryIdentifier) {
-            return true
-        }
-    }
-    if (this is FileRelatedCodeLocation) {
-        // Recognize fake std, such as when editing them as ordinary files.
-        val sourceFile = this.sourceFile
-        if (sourceFile.segments.firstOrNull()?.fullName == STANDARD_LIBRARY_NAME) {
-            return true
-        }
-    }
-    return false
 }
 
 internal fun destructureModuleBody(

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/Module.kt
@@ -37,7 +37,6 @@ import lang.temper.interp.ContinueCondition
 import lang.temper.interp.EmptyEnvironment
 import lang.temper.interp.immutableEnvironment
 import lang.temper.interp.importExport.Importer
-import lang.temper.interp.importExport.STANDARD_LIBRARY_NAME
 import lang.temper.interp.importExport.isEffectivelyStd
 import lang.temper.lexer.Genre
 import lang.temper.lexer.TokenSource
@@ -81,7 +80,6 @@ import lang.temper.value.StayLeaf
 import lang.temper.value.TBoolean
 import lang.temper.value.Tree
 import lang.temper.value.Value
-import lang.temper.value.isCore
 import lang.temper.value.toPseudoCode
 import kotlin.math.max
 

--- a/frontend/src/commonMain/kotlin/lang/temper/frontend/define/AddTemperTestInstructionsTo.kt
+++ b/frontend/src/commonMain/kotlin/lang/temper/frontend/define/AddTemperTestInstructionsTo.kt
@@ -3,7 +3,7 @@ package lang.temper.frontend.define
 import lang.temper.builtin.BuiltinFuns
 import lang.temper.common.Log
 import lang.temper.frontend.Module
-import lang.temper.frontend.isEffectivelyStd
+import lang.temper.interp.importExport.isEffectivelyStd
 import lang.temper.log.MessageTemplate
 import lang.temper.name.BuiltinName
 import lang.temper.name.ExportedName

--- a/frontend/src/commonTest/kotlin/lang/temper/frontend/SyntaxMacroStageTest.kt
+++ b/frontend/src/commonTest/kotlin/lang/temper/frontend/SyntaxMacroStageTest.kt
@@ -260,6 +260,12 @@ class SyntaxMacroStageTest {
     )
 
     @Test
+    fun connectedUnsupported() = assertModuleAtStage(
+        stageTestDir = StageTestDir("syntax-macro/connected-unsupported"),
+        moduleResultNeeded = true,
+    )
+
+    @Test
     fun reorder() = assertModuleAtStage(
         stageTestDir = StageTestDir("syntax-macro/reorder"),
     )

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/generate-code/sealed-connected-casts/expect/errors.json
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/generate-code/sealed-connected-casts/expect/errors.json
@@ -1,4 +1,9 @@
 [
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
     "Connected types cannot be targeted with is or as runtime type checks because multiple Temper types are allowed to connect to the same backend type: \u003c[C__1]\u003e from AnyValue!",
     "Connected types cannot be targeted with is or as runtime type checks because multiple Temper types are allowed to connect to the same backend type: \u003c[E__4]\u003e from S!"
 ]

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/errors.json
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/errors.json
@@ -1,0 +1,5 @@
+[
+    "At this time, users can connect only functions!",
+    "At this time, users can connect only functions!",
+    "At this time, rest parameters aren't supported in user connected functions!"
+]

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/errors.json
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/errors.json
@@ -1,5 +1,7 @@
 [
-    "At this time, users can connect only functions!",
-    "At this time, users can connect only functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
+    "At this time, users can connect only top-level functions!",
     "At this time, rest parameters aren't supported in user connected functions!"
 ]

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/syntaxMacro.temper
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/syntaxMacro.temper
@@ -1,13 +1,29 @@
 @typeDecl(NoConnectedTypesForNow) @stay @connected let `test//`.NoConnectedTypesForNow = type (NoConnectedTypesForNow);
-@fn @connected let `test//`.alsoNoRestArgsForNow;
+@fn @connected let `test//`.alsoNoRestArgsYet, @fn @visibility(\private) @connected butDefaultArgsDoWork__3;
 do {};
 class(\word, \NoConnectedTypesForNow, \concrete, true, @typeDefined(NoConnectedTypesForNow) fn {
     NoConnectedTypesForNow extends AnyValue;
-    @visibility(\public) let constructor__2 = fn constructor(@impliedThis(NoConnectedTypesForNow) this__0: NoConnectedTypesForNow) /* return__1 */: Void {};
+    @visibility(\public) @connected @fn let alsoNoConnectedMethodsYet__4 = (@connected fn alsoNoConnectedMethodsYet(@impliedThis(NoConnectedTypesForNow) this__0: NoConnectedTypesForNow) {
+        fn__5: do {
+          pureVirtual()
+        }
+    });
+    @fn @static @visibility(\public) @connected let notEvenStaticMethodsYet__6 = (@connected fn notEvenStaticMethodsYet {
+        fn__7: do {
+          pureVirtual()
+        }
+    });
+    @visibility(\public) let constructor__8 = fn constructor(@impliedThis(NoConnectedTypesForNow) this__1: NoConnectedTypesForNow) /* return__2 */: Void {};
 });
-`test//`.alsoNoRestArgsForNow = (@connected fn alsoNoRestArgsForNow(i__3 /* aka i */: Int) {
-    fn__5: do {
+`test//`.alsoNoRestArgsYet = (@connected fn alsoNoRestArgsYet(i__9 /* aka i */: Int) {
+    fn__11: do {
       abstractPanic()
     }
 });
-@connected let `test//`.alsoNoOtherDecls: Int = 5;
+@connected let `test//`.alsoNoOtherDeclsYet: Int = 5;
+REM("For now, this is the only case in this file without errors. Support like this\nis also tested in functional testing, but showing here also provides\ncontrast.", null, false);
+butDefaultArgsDoWork__3 = (@connected fn butDefaultArgsDoWork(i__12 /* aka i */: Int, j__13 /* aka j */: Int = 2) {
+    fn__14: do {
+      abstractPanic()
+    }
+});

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/syntaxMacro.temper
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/expect/syntaxMacro.temper
@@ -1,0 +1,13 @@
+@typeDecl(NoConnectedTypesForNow) @stay @connected let `test//`.NoConnectedTypesForNow = type (NoConnectedTypesForNow);
+@fn @connected let `test//`.alsoNoRestArgsForNow;
+do {};
+class(\word, \NoConnectedTypesForNow, \concrete, true, @typeDefined(NoConnectedTypesForNow) fn {
+    NoConnectedTypesForNow extends AnyValue;
+    @visibility(\public) let constructor__2 = fn constructor(@impliedThis(NoConnectedTypesForNow) this__0: NoConnectedTypesForNow) /* return__1 */: Void {};
+});
+`test//`.alsoNoRestArgsForNow = (@connected fn alsoNoRestArgsForNow(i__3 /* aka i */: Int) {
+    fn__5: do {
+      abstractPanic()
+    }
+});
+@connected let `test//`.alsoNoOtherDecls: Int = 5;

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/work/test/test.temper
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/work/test/test.temper
@@ -1,8 +1,20 @@
 @connected
-export class NoConnectedTypesForNow {}
+export class NoConnectedTypesForNow {
+  @connected
+  public alsoNoConnectedMethodsYet();
+
+  @connected
+  public static notEvenStaticMethodsYet();
+}
 
 @connected
-export let alsoNoRestArgsForNow(i: Int, ...more: List<Int>);
+export let alsoNoRestArgsYet(i: Int, ...more: List<Int>);
 
 @connected
-export let alsoNoOtherDecls: Int = 5;
+export let alsoNoOtherDeclsYet: Int = 5;
+
+// For now, this is the only case in this file without errors. Support like this
+// is also tested in functional testing, but showing here also provides
+// contrast.
+@connected
+private let butDefaultArgsDoWork(i: Int, j: Int = 2);

--- a/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/work/test/test.temper
+++ b/frontend/src/commonTest/resources/lang/temper/frontend/stage-tests/syntax-macro/connected-unsupported/work/test/test.temper
@@ -1,0 +1,8 @@
+@connected
+export class NoConnectedTypesForNow {}
+
+@connected
+export let alsoNoRestArgsForNow(i: Int, ...more: List<Int>);
+
+@connected
+export let alsoNoOtherDecls: Int = 5;

--- a/fundamentals/src/commonMain/kotlin/lang/temper/value/MacroEnvironment.kt
+++ b/fundamentals/src/commonMain/kotlin/lang/temper/value/MacroEnvironment.kt
@@ -10,6 +10,7 @@ import lang.temper.log.LogEntry
 import lang.temper.log.MessageTemplate
 import lang.temper.log.Position
 import lang.temper.log.Positioned
+import lang.temper.log.SharedLocationContext
 import lang.temper.name.NameMaker
 import lang.temper.name.Symbol
 import lang.temper.name.TemperName
@@ -179,6 +180,12 @@ interface MacroEnvironment : InterpreterCallback, Positioned, ConfigurationKey.H
      * Core module.
      */
     val isProcessingCore: Boolean get() = false
+
+    /**
+     * Depending on the situation, [sharedLocationContext] might be needed for
+     * accurate results.
+     */
+    fun isProcessingStd(sharedLocationContext: SharedLocationContext?): Boolean
 
     override val promises: Promises
 

--- a/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
@@ -36,7 +36,9 @@ internal val connectedDecorator = MetadataDecorator(
             }
             else -> when (val init = metadata[initSymbol]?.target) {
                 is FunTree -> when {
-                    // Seems we aren't able to gather formal params yet when this macro is called.
+                    // Neither instance nor static methods get in here because of different tree structures.
+                    // That's good for now.
+                    // Also, we don't get formal params yet when this macro is called, so loop trees.
                     init.children.any { maybeParam ->
                         when (val maybeParamParts = (maybeParam as? DeclTree)?.parts) {
                             null -> false
@@ -55,6 +57,7 @@ internal val connectedDecorator = MetadataDecorator(
             }
         }
     }
+    // Whether we had errors or not, move on with a void value.
     void
 }
 

--- a/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
@@ -1,14 +1,19 @@
 package lang.temper.interp
 
+import lang.temper.common.Log
+import lang.temper.log.MessageTemplate
 import lang.temper.name.Symbol
 import lang.temper.value.CallTree
+import lang.temper.value.DeclTree
 import lang.temper.value.FunTree
 import lang.temper.value.MacroActuals
 import lang.temper.value.Tree
 import lang.temper.value.Value
 import lang.temper.value.connectedSymbol
 import lang.temper.value.initSymbol
+import lang.temper.value.restFormalSymbol
 import lang.temper.value.symbolContained
+import lang.temper.value.typeDeclSymbol
 import lang.temper.value.void
 
 /**
@@ -21,7 +26,35 @@ import lang.temper.value.void
 internal val connectedDecorator = MetadataDecorator(
     connectedSymbol,
     findDecoratorInsertions = ::findConnectedDecoratorInsertions,
-) {
+) { args ->
+    // At this stage, we don't need the location context.
+    if (!(isProcessingCore || isProcessingStd(sharedLocationContext = null))) run check@{
+        val metadata = (args.rawTreeList.first() as? DeclTree)?.parts?.metadataSymbolMap ?: return@check
+        when {
+            typeDeclSymbol in metadata -> {
+                log(Log.Error, MessageTemplate.UserConnectedNotFun, pos, listOf())
+            }
+            else -> when (val init = metadata[initSymbol]?.target) {
+                is FunTree -> when {
+                    // Seems we aren't able to gather formal params yet when this macro is called.
+                    init.children.any { maybeParam ->
+                        when (val maybeParamParts = (maybeParam as? DeclTree)?.parts) {
+                            null -> false
+                            else -> restFormalSymbol in maybeParamParts.metadataSymbolMap
+                        }
+                    } -> {
+                        log(Log.Error, MessageTemplate.UserConnectedFunHasRest, pos, listOf())
+                    }
+                    else -> {
+                        // We support connected functions without rest params at this time.
+                    }
+                }
+                else -> {
+                    log(Log.Error, MessageTemplate.UserConnectedNotFun, pos, listOf())
+                }
+            }
+        }
+    }
     void
 }
 

--- a/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/ConnectedDecorator.kt
@@ -27,8 +27,11 @@ internal val connectedDecorator = MetadataDecorator(
     connectedSymbol,
     findDecoratorInsertions = ::findConnectedDecoratorInsertions,
 ) { args ->
-    // At this stage, we don't need the location context.
-    if (!(isProcessingCore || isProcessingStd(sharedLocationContext = null))) run check@{
+    // Whether we have errors or not, move on with a void value.
+    void.also check@{
+        isProcessingCore && return@check
+        // At this stage, we don't need the location context.
+        isProcessingStd(sharedLocationContext = null) && return@check
         val metadata = (args.rawTreeList.first() as? DeclTree)?.parts?.metadataSymbolMap ?: return@check
         when {
             typeDeclSymbol in metadata -> {
@@ -57,8 +60,6 @@ internal val connectedDecorator = MetadataDecorator(
             }
         }
     }
-    // Whether we had errors or not, move on with a void value.
-    void
 }
 
 val vConnectedDecorator = Value(connectedDecorator)

--- a/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/Interpreter.kt
@@ -25,12 +25,14 @@ import lang.temper.env.ReferentBit
 import lang.temper.env.ReferentBitSet
 import lang.temper.env.ReferentSource
 import lang.temper.env.or
+import lang.temper.interp.importExport.isEffectivelyStd
 import lang.temper.log.FailLog
 import lang.temper.log.LogEntry
 import lang.temper.log.LogSink
 import lang.temper.log.MessageTemplate
 import lang.temper.log.Position
 import lang.temper.log.Positioned
+import lang.temper.log.SharedLocationContext
 import lang.temper.log.spanningPosition
 import lang.temper.name.NameMaker
 import lang.temper.name.ParsedName
@@ -2474,6 +2476,10 @@ class Interpreter(
 
         override val isProcessingCore: Boolean
             get() = document.isCore
+
+        override fun isProcessingStd(sharedLocationContext: SharedLocationContext?): Boolean {
+            return document.nameMaker.namingContext.loc.isEffectivelyStd(sharedLocationContext)
+        }
 
         override fun connection(qname: String): ((Signature2) -> Value<*>)? {
             return this@Interpreter.connection(qname)

--- a/interp/src/commonMain/kotlin/lang/temper/interp/MetadataDecorator.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/MetadataDecorator.kt
@@ -80,11 +80,16 @@ class MetadataDecorator(
             return fail
         }
         val insertions = findDecoratorInsertions(args, symbolKey)
+        // Cache result across insertions because it doesn't depend on them.
+        var valuerResultCache: PartialResult? = null
         for (insertion in insertions) {
             val (decorated, insertionPoint) = insertion
             if (insertionPoint in 0..decorated.size) {
-                val calleePos = macroEnv.callee.pos
-                when (val valuerResult = macroEnv.valuer(args)) {
+                val valuerResult = when (valuerResultCache) {
+                    null -> macroEnv.valuer(args).also { valuerResultCache = it }
+                    else -> valuerResultCache
+                }
+                when (valuerResult) {
                     NotYet -> return NotYet
                     is Fail -> {
                         val logEntry = valuerResult.info
@@ -96,6 +101,7 @@ class MetadataDecorator(
                         return valuerResult
                     }
                     is Value<*> -> {
+                        val calleePos = macroEnv.callee.pos
                         (decorated as InnerTree).replace(insertionPoint until insertionPoint) {
                             V(calleePos, keyValue)
                             when (val error = TProblem.unpackOrNull(valuerResult)) {

--- a/interp/src/commonMain/kotlin/lang/temper/interp/importExport/ResolvedModuleSpecifier.kt
+++ b/interp/src/commonMain/kotlin/lang/temper/interp/importExport/ResolvedModuleSpecifier.kt
@@ -2,6 +2,12 @@ package lang.temper.interp.importExport
 
 import lang.temper.log.FilePath
 import lang.temper.log.FilePathSegment
+import lang.temper.log.FileRelatedCodeLocation
+import lang.temper.log.SharedLocationContext
+import lang.temper.name.DashedIdentifier
+import lang.temper.name.LibraryNameLocationKey
+import lang.temper.name.ModuleLocation
+import lang.temper.name.ModuleName
 
 /**
  * A prefix for resolved specifiers that refer to local [lang.temper.log.FilePath]s.
@@ -17,3 +23,21 @@ val STANDARD_LIBRARY_FILEPATH = FilePath(listOf(FilePathSegment(STANDARD_LIBRARY
 data class ResolvedModuleSpecifier(
     val text: String,
 )
+
+fun ModuleLocation.isEffectivelyStd(sharedLocationContext: SharedLocationContext?): Boolean {
+    if (this is ModuleName) {
+        if (this.isPreface) { return false }
+        val libraryName = sharedLocationContext?.get(this, LibraryNameLocationKey)
+        if (libraryName == DashedIdentifier.temperStandardLibraryIdentifier) {
+            return true
+        }
+    }
+    if (this is FileRelatedCodeLocation) {
+        // Recognize fake std, such as when editing them as ordinary files.
+        val sourceFile = this.sourceFile
+        if (sourceFile.segments.firstOrNull()?.fullName == STANDARD_LIBRARY_NAME) {
+            return true
+        }
+    }
+    return false
+}

--- a/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
+++ b/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
@@ -233,6 +233,14 @@ enum class MessageTemplate(
         "Function body required except for virtual methods or connected functions",
         CompilationPhase.CodeGeneration,
     ),
+    UserConnectedNotFun(
+        "At this time, users can connect only functions",
+        CompilationPhase.CodeGeneration,
+    ),
+    UserConnectedFunHasRest(
+        "At this time, rest parameters aren't supported in user connected functions",
+        CompilationPhase.CodeGeneration,
+    ),
     CannotExtend(
         "A class may not extend %s. Only named types and And(`&`) types may be extended",
         CompilationPhase.Interpreter,

--- a/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
+++ b/log/src/commonMain/kotlin/lang/temper/log/MessageTemplate.kt
@@ -234,7 +234,7 @@ enum class MessageTemplate(
         CompilationPhase.CodeGeneration,
     ),
     UserConnectedNotFun(
-        "At this time, users can connect only functions",
+        "At this time, users can connect only top-level functions",
         CompilationPhase.CodeGeneration,
     ),
     UserConnectedFunHasRest(


### PR DESCRIPTION
- Relates to #456
- Report error on user `@connected` except for top-level functions
- Don't check for either core or std, and move some std checking helper logic
- Call decorator macros only once each, even with multiple insertion points
- Test error cases
- In existing tests, allow previously applied cases that we don't really support to give errors for now
  - There's actually one ("rewrite-connected-decorator") syntax macro stage test (at least) that fakes being std to allow connected even in the past, so that's a nice side test for the std dodge, especially since we don't fail funtests with compiler errors in std